### PR TITLE
chore(github): add issue templates, project board docs, and setup script

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,77 @@
+name: Bug 报告
+description: 网站挂了 / 表现不对 / 控制台报错
+title: "[Bug] "
+labels: ["bug"]
+body:
+  - type: textarea
+    id: what_happened
+    attributes:
+      label: 发生了什么
+      description: 现象描述，越具体越好
+      placeholder: |
+        例: 打开 https://innoseed.csu.edu.cn/apply 提交表单后，
+        一直转圈，30 秒后跳到 500 错误页。
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: 期望行为
+      description: 应该是什么样
+    validations:
+      required: true
+
+  - type: textarea
+    id: repro_steps
+    attributes:
+      label: 复现步骤
+      description: 一步步列出
+      placeholder: |
+        1. 打开 /apply
+        2. 填写表单
+        3. 点击提交
+    validations:
+      required: true
+
+  - type: input
+    id: url
+    attributes:
+      label: 出问题的 URL
+    validations:
+      required: false
+
+  - type: dropdown
+    id: browser
+    attributes:
+      label: 浏览器
+      options:
+        - Chrome
+        - Safari
+        - Firefox
+        - Edge
+        - 微信内置
+        - 其他
+    validations:
+      required: false
+
+  - type: dropdown
+    id: device
+    attributes:
+      label: 设备
+      options:
+        - Desktop
+        - Mobile (iOS)
+        - Mobile (Android)
+        - Tablet
+        - Other
+    validations:
+      required: false
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: 控制台 / 网络日志 (可选)
+      description: F12 → Console / Network，把相关报错截图或文字贴上来
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,8 @@
+blank_issues_enabled: true
+contact_links:
+  - name: 💬 InnOSeed Lab 讨论区
+    url: https://github.com/CSU-InnOSeed/homepage/discussions
+    about: 想法、提问、不需要立刻执行的讨论放在这里
+  - name: 📋 招新看板 (Project board)
+    url: https://github.com/orgs/CSU-InnOSeed/projects
+    about: 查看所有招新流程 + 网站维护任务的总览

--- a/.github/ISSUE_TEMPLATE/content-idea.yml
+++ b/.github/ISSUE_TEMPLATE/content-idea.yml
@@ -1,0 +1,47 @@
+name: 文案 / 内容想法
+description: 还没想好怎么落地的内容灵感 — 文案、金句、版式灵感
+title: "[灵感] "
+labels: ["content", "P2"]
+body:
+  - type: dropdown
+    id: category
+    attributes:
+      label: 类别
+      options:
+        - 招新推文
+        - 官网 copy
+        - 公众号 / 知乎长文
+        - 演讲 / 路演稿
+        - 标语 / Slogan
+        - 其他
+    validations:
+      required: true
+
+  - type: textarea
+    id: idea
+    attributes:
+      label: 想法描述
+      description: 把灵感写出来，越具体越好
+      placeholder: |
+        例: 招新推的开头不要用「InnOSeed 是 XX 实验室」这种自我介绍
+        式开头，试试用一个真实项目切入，比如「去年我们做了一个 XX」
+        — 让读者先看到我们做了什么，再倒推回我们是谁。
+    validations:
+      required: true
+
+  - type: input
+    id: references
+    attributes:
+      label: 灵感来源 / 参考
+      description: 看到的别家文案、推文、书等
+    validations:
+      required: false
+
+  - type: textarea
+    id: next_step
+    attributes:
+      label: 建议的下一步
+      description: 这个想法可以怎么往下推
+      placeholder: "例: 写一个 500 字 draft，下次组会讨论"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/recruitment-task.yml
+++ b/.github/ISSUE_TEMPLATE/recruitment-task.yml
@@ -1,0 +1,82 @@
+name: 招新待办
+description: 招新流程里的具体任务 — 宣传、文案、面试跟进、申请审核
+title: "[招新] "
+labels: ["招新"]
+assignees: []
+body:
+  - type: dropdown
+    id: task_type
+    attributes:
+      label: 任务类型
+      description: 这个任务属于哪一类
+      options:
+        - 招新宣传（海报 / 朋友圈 / 群推）
+        - 文案撰写（公众号 / 知乎 / 朋友圈）
+        - 申请审核
+        - 面试跟进
+        - 录取 / 通知
+        - 招新 FAQ
+        - 其他
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: 优先级
+      options:
+        - P0 (本周必须完成)
+        - P1 (招新结束前)
+        - P2 (有时间再说)
+    validations:
+      required: true
+
+  - type: input
+    id: deadline
+    attributes:
+      label: 截止日期
+      description: 格式 YYYY-MM-DD
+      placeholder: "2026-07-20"
+    validations:
+      required: true
+
+  - type: input
+    id: related_applicant
+    attributes:
+      label: 关联申请人
+      description: 如果是跟进具体某位申请人，填他的姓名 / 报名号 / 申请链接
+      placeholder: "如: 张三 / 报名号 #42 / 申请表链接"
+    validations:
+      required: false
+
+  - type: textarea
+    id: description
+    attributes:
+      label: 任务描述
+      description: 具体要做什么，越具体越好
+      placeholder: |
+        例: 给公众号写一篇 24 级招新推送，重点突出 InnOSeed 的
+        「项目制 + 跨方向」特色，对标一下隔壁 RoboMaster 队的招新推。
+    validations:
+      required: true
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: 验收标准
+      description: 怎么算完成了
+      placeholder: |
+        - [ ] 推文排版符合 Lab 视觉规范
+        - [ ] 包含报名链接
+        - [ ] 在微信群和朋友圈各发一次
+    validations:
+      required: true
+
+  - type: input
+    id: related_links
+    attributes:
+      label: 相关链接
+      description: 参考资料、原型、之前的推文等
+      placeholder: "可多个链接，换行分隔"
+    validations:
+      required: false

--- a/.github/ISSUE_TEMPLATE/website-change.yml
+++ b/.github/ISSUE_TEMPLATE/website-change.yml
@@ -1,0 +1,85 @@
+name: 网站修改
+description: 对 InnOSeed 官网 (homepage) 的内容、视觉、代码、数据修改请求
+title: "[网站] "
+labels: ["website"]
+body:
+  - type: dropdown
+    id: change_type
+    attributes:
+      label: 变更类型
+      options:
+        - 文案 (copy)
+        - 视觉 (style / animation)
+        - 代码 (component / logic)
+        - 数据 (招募方向 / 标签 / 面试官)
+        - 部署 / 基础设施
+        - 其他
+    validations:
+      required: true
+
+  - type: dropdown
+    id: surface
+    attributes:
+      label: 影响范围
+      options:
+        - 所有端
+        - 桌面端
+        - 移动端
+        - 仅后端 / API
+    validations:
+      required: true
+
+  - type: dropdown
+    id: priority
+    attributes:
+      label: 紧急程度
+      options:
+        - 紧急 (招新期间线上挂掉)
+        - 本周内
+        - 招新结束前
+        - 排期再说
+    validations:
+      required: true
+
+  - type: textarea
+    id: current_state
+    attributes:
+      label: 现状
+      description: 当前是什么样，有什么问题
+      placeholder: |
+        例: 招新页的「项目方向」卡片在移动端排版错乱，
+        第一行只显示 1.5 个标签就换行了。
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected_state
+    attributes:
+      label: 期望
+      description: 改完之后应该是什么样
+      placeholder: |
+        例: 移动端下每行至少显示 2 个完整标签；视觉规范沿用 manifesto
+        卡片的字号层级。
+    validations:
+      required: true
+
+  - type: input
+    id: references
+    attributes:
+      label: 参考 / 截图链接
+      description: Figma、竞品、之前的版本等
+      placeholder: "可多个链接"
+    validations:
+      required: false
+
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: 验收标准
+      description: 怎么算改完了
+      placeholder: |
+        - [ ] 移动端 (375 / 768) 视觉正常
+        - [ ] Vercel 预览链接在贴出来
+        - [ ] 桌面端没回归
+    validations:
+      required: true

--- a/.github/PROJECT_SETUP.md
+++ b/.github/PROJECT_SETUP.md
@@ -1,0 +1,119 @@
+# 招新项目板使用说明
+
+> 这份文档给 InnOSeed 的所有成员看 —— 招新期间（以及平时维护官网）的所有协作都在 GitHub 上发生。
+
+## 一张图看懂结构
+
+```
+   Issue  ←───  招新待办 / 网站修改 / Bug 报告 / 文案灵感
+     │
+     ├──  Labels:  招新 / website / content / P0 / P1 / P2 / blocked
+     ├──  Milestone:  招新启动 / 一面 / 录取公布
+     └──  Project:   招新 2026 (看板: Todo / In Progress / Done)
+```
+
+每条具体的事 = 一个 **Issue**。项目板 = 所有 Issue 的看板视图。Milestone = 阶段截止日期。Label = 分类。
+
+---
+
+## 怎么开一条新任务
+
+1. 进仓库 → **Issues** → **New issue**
+2. 根据类型选模板：
+   - **招新待办** — 招新流程、宣传、面试跟进
+   - **网站修改** — 官网的代码、文案、视觉、数据
+   - **文案 / 内容想法** — 灵感，还没成型
+   - **Bug 报告** — 网站挂了
+   - 都不合适 → 选 **Open a blank issue**
+3. 填完模板提交 — 标题会自动带前缀（`[招新]` / `[网站]` …）
+4. 提交后到 **Project board** 把卡片拖到对应列
+5. 自己能解决的指给自己 (`assignee`)，需要别人帮忙的留空并在群里 @ 人
+
+---
+
+## 项目板 (Project) 怎么用
+
+看板地址: https://github.com/orgs/CSU-InnOSeed/projects *(具体链接看实际项目)*
+
+| 列 | 含义 |
+|---|---|
+| **Todo** | 待开始 |
+| **In Progress** | 正在做 |
+| **Done** | 完成 (卡片 14 天后自动归档) |
+
+**日常节奏:**
+- 每天开站看一眼 Todo 列 — 有没有卡住自己的 (`blocked` label)
+- 自己的活做完了从 In Progress 拖到 Done
+- 招新冲刺期（招新启动前 1 周、一面前、录取前）建议每天站会同步 5 分钟
+
+---
+
+## Label 体系
+
+### 任务类型
+| Label | 含义 | 颜色 |
+|---|---|---|
+| `招新` | 招新流程相关 | 红 `#d73a4a` |
+| `website` | 官网维护 | 蓝 `#0075ca` |
+| `content` | 文案 / 灵感 | 紫 `#7057ff` |
+| `bug` | 网站 bug | 红 `#ee0701` |
+| `docs` | 文档 | 浅蓝 `#0e8a16` |
+| `interview` | 面试相关 | 橙 `#fbca04` (文字黑) |
+
+### 紧急程度
+| Label | 含义 |
+|---|---|
+| `P0` | 紧急 (招新期间线上挂掉 / 一面前必须完成) |
+| `P1` | 本周内 / 招新结束前 |
+| `P2` | 有时间再说 |
+
+### 状态
+| Label | 含义 |
+|---|---|
+| `blocked` | 卡住等外部输入 (在群里说一声) |
+
+---
+
+## Milestone (招新阶段)
+
+| Milestone | 含义 | 默认 DDL |
+|---|---|---|
+| 招新启动 | 招新宣发正式启动 | 招新前 ~10 天 |
+| 招新截止 | 报名通道关闭 | 招新日 |
+| 一面 | 一面进行中 | 招新日 + 1 周 |
+| 录取公布 | 录取名单发布 | 一面后 ~3 天 |
+
+> ⚠️ 上面 DDL 是**默认值**，具体日期在 milestone 描述里改。
+
+每个 issue 挂一个 milestone —— milestone 页面就是这个阶段的进度条。
+
+---
+
+## 一些约定
+
+- **标题** 用动词开头：「补 24 级招新问答」/「修移动端 manifesto 字号」
+- **一个 issue 一件事** — 别把「修 BUG + 写推文」塞一起
+- **完成就关** — 做完从 project 拖到 Done，issue 同步 close，**不要拖回去**
+- **自己认领自己** — 没人指派的活谁先动手就 assignee 填自己
+- **卡住就标 blocked** — 别默默卡着，在群里说一声 + label 改 `blocked`
+
+---
+
+## 给维护者的初始化命令
+
+第一次用这套流程？在 `innoseed-landing` 仓库根目录跑：
+
+```bash
+# 1. 登录 gh CLI (只需一次)
+gh auth login
+
+# 2. 跑一键 setup 脚本 (建 labels + milestones)
+./scripts/setup-github-project.sh
+
+# 3. 在 Web 端建 Project:
+#    https://github.com/orgs/CSU-InnOSeed/projects
+#    → New project → Template 选 "Automated kanban"
+#    → 标题: "InnOSeed 招新 2026"
+```
+
+详细参数看脚本注释。

--- a/scripts/setup-github-project.sh
+++ b/scripts/setup-github-project.sh
@@ -1,0 +1,120 @@
+#!/usr/bin/env bash
+# setup-github-project.sh
+#
+# 一键给 CSU-InnOSeed/homepage 仓库建好招新协作所需的:
+#   - 全部 labels (类型 + 优先级 + 状态)
+#   - 全部 milestones (招新阶段)
+#
+# Project 看板本身必须在 Web 端创建 (gh project create 不支持 --template),
+# 脚本最后会打印入口链接。
+#
+# 用法:
+#   1) gh auth login                       # 第一次用需先登录
+#   2) gh auth refresh -s project         # 允许 gh 操作 Projects
+#   3) ./scripts/setup-github-project.sh   # 跑本脚本
+#
+# 安全: 脚本是幂等的, 已存在的 label 会用 --force 更新颜色/描述。
+#       重新跑不会重复创建 milestone (gh milestone create 会失败 → 跳过)。
+
+set -euo pipefail
+
+REPO="CSU-InnOSeed/homepage"
+
+# -------- 颜色 --------
+RED=$'\033[0;31m'
+GREEN=$'\033[0;32m'
+YELLOW=$'\033[1;33m'
+BLUE=$'\033[0;34m'
+NC=$'\033[0m'
+
+info() { printf "${BLUE}[info]${NC} %s\n" "$*"; }
+ok()   { printf "${GREEN}[ ok ]${NC} %s\n" "$*"; }
+warn() { printf "${YELLOW}[warn]${NC} %s\n" "$*"; }
+fail() { printf "${RED}[fail]${NC} %s\n" "$*" >&2; exit 1; }
+
+# -------- 前置检查 --------
+command -v gh >/dev/null 2>&1 || fail "gh CLI 未安装: brew install gh"
+gh auth status >/dev/null 2>&1 || fail "未登录 gh CLI, 先跑: gh auth login"
+
+info "目标仓库: $REPO"
+gh repo view "$REPO" >/dev/null 2>&1 || fail "无访问权限或仓库不存在"
+
+# -------- 1. Labels --------
+# 格式: name|color|description
+LABELS=(
+  # 类型
+  "招新|d73a4a|招新流程相关任务 (宣传/面试/录取)"
+  "website|0075ca|官网维护 (代码/文案/视觉/数据)"
+  "content|7057ff|文案 / 灵感"
+  "bug|ee0701|网站 bug"
+  "docs|0e8a16|文档相关"
+  "interview|fbca04|面试相关 (文字需黑色)"
+  # 优先级
+  "P0|b60205|紧急 — 招新期间线上挂掉 / 截止日前必须完成"
+  "P1|d93f0b|本周内 / 招新结束前"
+  "P2|fbca04|有时间再说 (文字需黑色)"
+  # 状态
+  "blocked|cccccc|卡住等外部输入"
+)
+
+info "创建 / 更新 labels (共 ${#LABELS[@]} 个)..."
+for entry in "${LABELS[@]}"; do
+  IFS='|' read -r name color desc <<<"$entry"
+  if gh label create "$name" --repo "$REPO" --color "$color" --description "$desc" --force >/dev/null 2>&1; then
+    ok "label: $name"
+  else
+    warn "label: $name (跳过, 创建失败)"
+  fi
+done
+
+# -------- 2. Milestones --------
+# 格式: title|description|due_on (ISO 8601 date)
+# 默认日期基于 2026 暑期招新, 创建后请在 Web 端按真实节奏调整。
+MILESTONES=(
+  "招新启动|招新宣发正式启动, 公众号 + 朋友圈 + 群推|2026-07-20"
+  "招新截止|报名通道关闭|2026-07-27"
+  "一面|一面进行中|2026-08-03"
+  "录取公布|录取名单发布 + 通知|2026-08-06"
+)
+
+info "创建 milestones (共 ${#MILESTONES[@]} 个)..."
+for entry in "${MILESTONES[@]}"; do
+  IFS='|' read -r title desc due <<<"$entry"
+  if gh api "repos/$REPO/milestones" \
+       -f title="$title" \
+       -f description="$desc" \
+       -f due_on="${due}T23:59:59Z" >/dev/null 2>&1; then
+    ok "milestone: $title (DDL $due)"
+  else
+    warn "milestone: $title (跳过, 可能已存在 — 调 Web 端改 DDL)"
+  fi
+done
+
+# -------- 3. Issue 模板已随仓库发布 --------
+info "Issue 模板位置: .github/ISSUE_TEMPLATE/"
+ls .github/ISSUE_TEMPLATE/*.yml 2>/dev/null | while read -r f; do
+  ok "  - $f"
+done
+
+# -------- 4. Project 看板 (需手动) --------
+cat <<EOF
+
+${GREEN}========================================${NC}
+${GREEN} GitHub Project 需要在 Web 端创建 ${NC}
+${GREEN}========================================${NC}
+
+gh CLI 当前版本不支持从模板创建 Project, 请在浏览器里点一下:
+
+  1. 打开: ${BLUE}https://github.com/orgs/CSU-InnOSeed/projects${NC}
+  2. 点 "New project"
+  3. 模板选 ${YELLOW}"Automated kanban"${NC} (带自动归档)
+  4. 标题: ${YELLOW}InnOSeed 招新 2026${NC}
+  5. 可见性: Private (仅成员可见)
+  6. 创建后, 到 Project 设置里:
+     - "Manage access" → 把 repo 关联上
+     - 描述里贴上链接: ${BLUE}.github/PROJECT_SETUP.md${NC}
+
+完成后回到项目板, 把现有 issue 拖进 Todo 列, 开干。
+
+详细使用说明: .github/PROJECT_SETUP.md
+EOF


### PR DESCRIPTION
## What

为招新 + 官网维护协作搭建 GitHub 端的基础设施。

## Changes

- \`.github/ISSUE_TEMPLATE/\` — 4 个 issue 表单 (招新待办 / 网站修改 / 文案灵感 / Bug 报告) + 模板选择器
- \`.github/PROJECT_SETUP.md\` — 给整个 Lab 看的工作流文档 (label / milestone / 看板约定)
- \`scripts/setup-github-project.sh\` — 幂等的一键 setup 脚本 (labels + milestones)

## Already done (on the repo)

通过 setup 脚本已建好:
- 10 个 label: 招新 / website / content / bug / docs / interview / P0 / P1 / P2 / blocked
- 4 个 milestone: 招新启动 (7/20) / 招新截止 (7/27) / 一面 (8/3) / 录取公布 (8/6)

⚠️ Milestone DDL 是默认占位值, **merge 后请到 https://github.com/CSU-InnOSeed/homepage/milestones 按真实节奏调整**。

## TODO (需要手工)

- [ ] Web 端建 Project 看板: https://github.com/orgs/CSU-InnOSeed/projects → New project → 模板 "Automated kanban" → 标题 "InnOSeed 招新 2026" → Private
- [ ] Project settings → Manage access → 关联本 repo
- [ ] 调整 milestone DDL
- [ ] 把本 PR merge 进 main 后, issue 模板和 PROJECT_SETUP.md 才会生效

## 怎么测

merge 前可以在 PR 的 Files changed 标签里直接看 4 个 yml 表单的实际效果预览 (GitHub 会自动渲染), 不用本地起服务。

## 设计依据

见 \`.github/PROJECT_SETUP.md\`。