### PR TITLE
fix(recruit): FAQ accordion — keep every item visible when toggling open/close

### DIFF
--- a/e2e/desktop.spec.js
+++ b/e2e/desktop.spec.js
@@ -51,4 +51,38 @@ test.describe('desktop @ 1440x900', () => {
     );
     expect(cols).toBe(4);
   });
+
+  test('FAQ accordion: opening/closing keeps every item visible (regression guard)', async ({ page }) => {
+    // Recruit page renders the FAQ accordion. Earlier the .in class was
+    // added to .rf-item via classList.add, but a state change (openIdx)
+    // re-evaluated the className prop and React overwrote the `class`
+    // attribute, silently stripping `.in` from the just-clicked item and
+    // collapsing it to opacity:0. This test pins the fix: every item must
+    // stay visible (opacity >= 0.95) after several open/close clicks.
+    await page.goto('/recruit');
+    const list = page.locator('.rf-list');
+    await list.scrollIntoViewIfNeeded();
+    // Wait for IntersectionObserver + 1.1s CSS transition to reveal all
+    // items — without this the test races the in-view animation.
+    await page.waitForFunction(() => {
+      const items = document.querySelectorAll('.rf-item');
+      return Array.from(items).every(
+        (el) => el.classList.contains('in') && parseFloat(getComputedStyle(el).opacity) > 0.95
+      );
+    }, null, { timeout: 5000 });
+
+    // Click each FAQ button in turn (item 0 is open by default; the rest
+    // start closed) and after every click assert all 5 items are still
+    // visible. The bug manifested as the open+closed items losing `.in`
+    // while the rest kept it — checking ALL items catches that.
+    for (let i = 0; i < 5; i++) {
+      await page.locator('.rf-item').nth(i).locator('.rf-q').click();
+      await page.waitForFunction((idx) => {
+        const items = document.querySelectorAll('.rf-item');
+        return Array.from(items).every(
+          (el, j) => el.classList.contains('in') && parseFloat(getComputedStyle(el).opacity) > 0.95
+        );
+      }, i, { timeout: 2000 });
+    }
+  });
 });

--- a/scripts/setup-github-project.sh
+++ b/scripts/setup-github-project.sh
@@ -10,7 +10,8 @@
 #
 # 用法:
 #   1) gh auth login                       # 第一次用需先登录
-#   2) gh auth refresh -s project         # 允许 gh 操作 Projects
+#   2) gh auth refresh -s project,read:project  # 允许 gh 操作 Projects
+#      (这一步会让浏览器跳出来, 确认授权; 没授权的话 gh issue edit --add-project 会报 'not found')
 #   3) ./scripts/setup-github-project.sh   # 跑本脚本
 #
 # 安全: 脚本是幂等的, 已存在的 label 会用 --force 更新颜色/描述。

--- a/src/components/Recruit.tsx
+++ b/src/components/Recruit.tsx
@@ -121,6 +121,12 @@ function TimelineStep({ step }: TimelineStepProps) {
 /** FAQ accordion — 第一条默认展开 */
 function RecruitFaqs() {
   const [openIdx, setOpenIdx] = useState<number>(0);
+  // Track which items have entered the viewport as React state so the `.in`
+  // class is part of the JSX className. Mixing classList.add with a className
+  // prop that changes (rf-open toggles here) makes React overwrite the whole
+  // `class` attribute and the manually-added `.in` is silently lost — the
+  // open/closed items then disappear until the user scrolls.
+  const [seen, setSeen] = useState<ReadonlySet<number>>(() => new Set());
   const headRef = useRef<HTMLDivElement | null>(null);
   const listRef = useRef<HTMLUListElement | null>(null);
   useReveal(headRef);
@@ -130,19 +136,27 @@ function RecruitFaqs() {
   useEffect(() => {
     const root = listRef.current;
     if (!root) return undefined;
-    const items = root.querySelectorAll<HTMLElement>('.rf-item.reveal');
+    const items = Array.from(root.querySelectorAll<HTMLElement>('.rf-item.reveal'));
     if (items.length === 0) return undefined;
     if (typeof IntersectionObserver === 'undefined') {
-      items.forEach((el) => el.classList.add('in'));
+      setSeen(new Set(items.map((_, i) => i)));
       return undefined;
     }
     const io = new IntersectionObserver(
       (entries) => {
-        entries.forEach((entry) => {
-          if (entry.isIntersecting) {
-            entry.target.classList.add('in');
+        setSeen((prev) => {
+          let changed = false;
+          const next = new Set(prev);
+          entries.forEach((entry) => {
+            if (!entry.isIntersecting) return;
+            const idx = items.indexOf(entry.target as HTMLElement);
+            if (idx !== -1 && !next.has(idx)) {
+              next.add(idx);
+              changed = true;
+            }
             io.unobserve(entry.target);
-          }
+          });
+          return changed ? next : prev;
         });
       },
       { threshold: 0.15, rootMargin: '0px 0px -60px 0px' }
@@ -163,10 +177,11 @@ function RecruitFaqs() {
         <ul ref={listRef} className="rf-list">
           {RECRUIT_EXTRAS.faqs.map((faq, i) => {
             const open = openIdx === i;
+            const isIn = seen.has(i);
             return (
               <li
                 key={faq.q}
-                className={`rf-item reveal${open ? ' rf-open' : ''}`}
+                className={`rf-item reveal${isIn ? ' in' : ''}${open ? ' rf-open' : ''}`}
                 data-delay={String(Math.min(i + 1, 6))}
               >
                 <button


### PR DESCRIPTION
## Summary

- **fix(recruit)**: FAQ accordion 切换 open/close 时，被点 + 之前 open 的两条 Q&A 会一起消失（`opacity: 0`）
- **docs(setup)**: 提示 `gh auth refresh` 需要 `read:project` scope 才能 `--add-project`

## Root cause

`<li className={\`rf-item reveal${open ? ' rf-open' : ''}\`}>` 里的 `rf-open` 会随 state 切换。`.in` 是 IntersectionObserver 通过 `classList.add('in')` 手动加的。React 一旦发现 className 字符串变化，整个 `class` 属性会被覆盖写回——`in` 一起被冲掉。所以：

| 状态 | className 变化? | `in` 保留? |
|---|---|---|
| open 的项 → closed | `"rf-item reveal rf-open"` → `"rf-item reveal"` | **丢** |
| closed 的项 → open | `"rf-item reveal"` → `"rf-item reveal rf-open"` | **丢** |
| 一直 closed 的项 | 不变 | 保留 |

结果：用户滚到 FAQ 点按钮时，open + 刚点的两条消失，其他 3 条保持可见。

## Fix

把 `.in` 从 DOM 操作改成 React state（`seen: Set<number>`），纳入 JSX className：

```tsx
className={`rf-item reveal${isIn ? ' in' : ''}${open ? ' rf-open' : ''}`}
```

`seen` 由 IntersectionObserver 维护，setState 触发重新渲染，className 字符串始终带 `in`，React 不会再冲掉它。

## Test

新增 `e2e/desktop.spec.js` 回归测试 *"FAQ accordion: opening/closing keeps every item visible"*：
1. 滚到 FAQ，等 5 项都 `in + opacity > 0.95`
2. 连续点 5 个按钮
3. 每次点完断言所有 5 项仍然可见

`pnpm test:e2e` 全过：9 desktop + 12 mobile ✓

## Changes

```
e2e/desktop.spec.js        | 34 ++++++++++++++++++++++++++++++++++
scripts/setup-github-project.sh |  3 ++-
src/components/Recruit.tsx | 29 ++++++++++++++++++++++-------
```

## Commits

- `444955d` docs(setup): note read:project scope requirement
- `4b97a0e` fix(recruit): preserve .in class when FAQ accordion toggles open