### PR TITLE
feat(minicamp): minicamp.innoseed.club subdomain + apply Done-step copy

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,9 @@ vite.config.d.ts
 # tsc -p tsconfig.node.json emits vite.config.js as a side effect.
 # Source of truth is vite.config.ts; the .js is regenerated on demand.
 vite.config.js
+
+# tsconfig.node.json includes src/content/site.ts with composite:true,
+# which emits site.js + site.d.ts as cross-project ref artifacts. Source
+# of truth is src/content/site.ts.
+src/content/site.js
+src/content/site.d.ts

--- a/.pi/skills/innoseed-deploy/SKILL.md
+++ b/.pi/skills/innoseed-deploy/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: innoseed-deploy
+description: Deploy workflow for the InnOSeed Lab landing (innoseed.club) — local subdomain verification with chromium --host-resolver-rules, commit + PR + CI, Vercel domain attachment, DNS CNAME setup, and branch cleanup. Use when shipping a change to main, adding a new subdomain (e.g. minicamp.innoseed.club), or pruning stale branches.
+---
+
+# InnOSeed Deploy
+
+End-to-end workflow for shipping changes to the InnOSeed landing site. Three
+phases — verify locally, push for review, finish the deploy by hand in
+Vercel + DNS.
+
+## Repository invariants (do not violate)
+
+From `AGENTS.md`:
+
+- **Don't `vercel deploy` manually.** CI is the authoritative deploy
+  path. Push to a branch, open a PR, CI builds + Vercel deploys the
+  preview, then merge → production.
+- **`framework: null` in `vercel.json`** is intentional, do not let
+  Vercel infer.
+- **Branch prefix `codex/`** (or `MciG-ggg/` matching existing style —
+  see `git for-each-ref`).
+- **Conventional commits**: `feat / fix / perf / refactor / chore / docs`.
+- **TypeScript strict**: don't loosen `tsconfig.json`.
+- **Don't bypass `pnpm-workspace.yaml`**: pnpm 11 needs it for esbuild.
+
+## Phase 1 — verify locally
+
+```bash
+# 1. Static checks + build + tests. Must all be green.
+pnpm typecheck
+pnpm exec tsc -p tsconfig.node.json
+pnpm build
+pnpm test:e2e
+pnpm test:tag-codes
+
+# 2. Subdomain behavior check (only if the change touches hostname
+# routing or adds a new route / subdomain). Self-contained: starts vite
+# preview, runs 4 browser assertions, kills the server. Exit code 0
+# means OK.
+pnpm verify:subdomain
+```
+
+`pnpm verify:subdomain` exercises what `e2e/minicamp.spec.js` cannot:
+the host-aware `<Navigate>` at `/`. It uses Chromium's
+`--host-resolver-rules` to map `minicamp.innoseed.club` → `127.0.0.1`
+without touching `/etc/hosts` (no sudo needed). The full flag set it
+needs (already wired in the script):
+
+```
+--host-resolver-rules=MAP minicamp.innoseed.club 127.0.0.1
+--no-proxy-server
+--proxy-server=direct://   # Chromium needs both flags; --no-proxy-server
+                           # alone doesn't always clear its detected proxy.
+```
+
+If you change the hostname list (e.g. adding a new subdomain), edit
+`SUBDOMAIN` near the top of `scripts/verify-subdomain.mjs`. The script
+asserts 4 things:
+
+1. `minicamp.innoseed.club/` redirects to `/minicamp` + renders
+   subdomain chrome (4 tracks, 4 timeline steps).
+2. `minicamp.innoseed.club/apply` still lands on Apply (not hijacked).
+3. `127.0.0.1:8765/` lands on the main landing page (no redirect).
+4. `127.0.0.1:8765/minicamp` renders the page with full Nav (NOT
+   subdomain chrome).
+
+## Phase 2 — commit, push, open PR
+
+```bash
+# Branch off main. Use codex/<slug> or MciG-ggg/<slug>.
+git checkout main && git pull
+git checkout -b codex/<short-slug>
+
+# Stage deliberately — never `git add .`. Composite-emitted .d.ts/.js
+# are gitignored, but verify with `git status --short` before commit.
+git add <specific paths>
+
+git commit -F- <<'EOF'
+<type>(<scope>): <subject>
+
+<body explaining what + why, not how>
+EOF
+
+git push -u origin HEAD
+
+# Open the PR. Body in a file (backticks in inline strings get
+# interpolated by bash).
+gh pr create --title "<same as commit subject>" --body-file /tmp/pr-body.md
+gh pr checks <num>          # wait for Vercel + CI to go green
+```
+
+**Do not push directly to main.** Always PR so CI runs and someone can
+review. Vercel auto-deploys production on merge.
+
+### Commit message conventions
+
+```
+feat(minicamp): add minicamp.innoseed.club subdomain
+fix(apply): stack CTA buttons on tablet
+perf(images): serve AVIF variants
+chore(site): update copyright
+docs(ag): document deploy workflow
+```
+
+## Phase 3 — make the subdomain reachable (one-time per new domain)
+
+`vercel.json` rewrites `/`, `/apply`, `/events`, `/recruit`, `/minicamp`
+to `/index.html` — same SPA serves every host. To bind a new subdomain:
+
+```bash
+# A. Vercel side (browser-only, can't be scripted from CLI):
+#    1. Vercel dashboard → innoseed-landing → Settings → Domains.
+#    2. Add the new domain (e.g. minicamp.innoseed.club). Vercel tells
+#       you the target (usually cname.vercel-dns.com).
+#    3. Wait for Vercel to issue the SSL cert after DNS resolves.
+
+# B. DNS side (provider-specific, e.g. Cloudflare):
+#    CNAME  minicamp  →  cname.vercel-dns.com
+#    Proxy: DNS only (off the orange cloud) — Cloudflare's proxy breaks
+#    Vercel's SSL issuance.
+
+# C. Verify:
+curl -I https://minicamp.innoseed.club/      # 200 from Vercel
+open https://minicamp.innoseed.club/         # browser lands on Mini Camp
+```
+
+`vercel.json` does **not** need editing for new subdomains — same SPA
+rewrite rules cover every host. Only `package.json`, `vite.config.ts`,
+and `src/App.tsx` (hostname detection) need code changes when adding a
+subdomain.
+
+## Branch cleanup
+
+Before cleanup, check what's safe to delete:
+
+```bash
+git for-each-ref --format='%(refname:short)' refs/heads/ refs/remotes/
+
+# '+' marker on local branches = checked out in another worktree.
+# Don't `git branch -D` those.
+
+# Remote branches: only safe to delete if merged into main.
+for b in $(git branch -r | grep -v HEAD); do
+  git merge-base --is-ancestor $b origin/main \
+    && echo "DELETE OK: $b" \
+    || echo "KEEP (not merged): $b"
+done
+
+# Confirm before deleting — output is dry-run only.
+```
+
+`git fetch --prune` cleans up stale remote-tracking branches after
+deletions on origin.
+
+## Troubleshooting
+
+| Symptom | Cause |
+| --- | --- |
+| `vite preview` returns 502 / 403 on `minicamp.innoseed.club` from curl | Vite 5 Host header check. Either use `vite.verify-subdomain.config.ts` (sets `preview.allowedHosts: true`) or set Host header to `127.0.0.1:8765` in curl. |
+| `pnpm verify:subdomain` reports `subdomain_root.ok: false` but `pnpm preview` works | Missing `--proxy-server=direct://` flag. Both `--no-proxy-server` and `--proxy-server=direct://` are required. |
+| `vite preview` says `Port 8765 in use` | A previous run didn't clean up. `pkill -9 -f vite` then retry. |
+| `git push` rejected — non-fast-forward | `git fetch origin && git rebase origin/main`. |
+| `gh pr create` fails with `No default branch` | `gh repo set-default` or pass `--base main`. |
+| `pnpm exec tsc -p tsconfig.node.json` emits `src/content/site.d.ts` + `site.js` | Composite-mode cross-project ref artifact from `tsconfig.node.json`. Already in `.gitignore` — verify `git status` is clean before commit. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -81,6 +81,7 @@ pnpm test:e2e                     # 29 个烟雾测试 (~12s)
 | `/` | `App.tsx` 默认分支 | 9 个 section 组件 + `Nav` + `Footer` |
 | `/apply` | `pages/Apply.tsx` | 4 步表单,自身管 step state,**不**渲染 `Nav` / `Footer` (用户从 Hero CTA 进入) |
 | `/events` `/recruit` | `pages/Events.tsx` / `pages/Recruit.tsx` | 渲染 `Nav` + 复用 `components/Events` / `components/Recruit` (传 `showHead={false}` 避免双 h2) + `Footer` |
+| `/minicamp` | `pages/MiniCamp.tsx` | Mini Camp 招新专用页。`minicamp.innoseed.club/` 根路径会被 `App.tsx` 同步 `<Navigate>` 重定向到这里。子域名下用 `SubdomainHeader` / `SubdomainFooter` 极简 chrome;主站下走完整 `Nav` + `Footer`。内容数据在 `src/content/site.ts` 的 `MINICAMP` 块 |
 | `*` | `pages/NotFound.tsx` | 走 Vercel 404 兜底,前端 NotFound 兜客户端路由 |
 
 **section id 锚点(供 nav 跳转)**:`#top` `#manifesto` `#pillars` `#members` `#events` `#recruit`。新增 section 必须:① 加 id ② 同步 `NAV_LINKS` ③ 跑 `pnpm test:e2e` 验 `checkNavSmoothScroll` 还过。

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
 | `/apply` | `Apply` (4 步: Guide → Pick Interviewer → Application → Done) | 招新表单 → POST `/api/apply` |
 | `/events` | `Nav + EventsPage + Footer` | 复刻首页 `#events` section |
 | `/recruit` | `Nav + RecruitPage + Footer` | 复刻首页 `#recruit` section + 时间线 + FAQ |
+| `/minicamp` | `MiniCampPage` | Mini Camp 招新专用页;`minicamp.innoseed.club/` 根路径也走这条 |
 | `*` | `NotFound` | 服务端由 Vercel `dist/404.html` 先返回 404 |
 
 ## 技术栈
@@ -131,6 +132,17 @@ build 时由 `vite.config.ts` 的两个内联插件处理:
    - **阿里云 / 腾讯云** → 按 Vercel 给的值填
 3. 等 DNS 传播 + Vercel 颁 SSL (5–30 分钟)
 4. 旧 SvelteKit 链接自动兼容: `mailto:contact@innoseed.club` / `innoseed.club/events` / `innoseed.club/recruit` 落到 v4 对应路由
+
+## 子域名 (minicamp.innoseed.club)
+
+Mini Camp 招新专用子域名。**不**需要新建 Vercel project — 同一个 SPA 多绑一个域名:
+
+1. Vercel dashboard → `innoseed-landing` → Settings → Domains → 添加 `minicamp.innoseed.club`
+2. DNS provider 加 Vercel 给出的 CNAME (`minicamp` 子域名)
+3. 路由逻辑在 [`src/App.tsx`](./src/App.tsx) 里:`/` 路径检测到 hostname 以 `minicamp.` 开头时,同步 `<Navigate>` 到 `/minicamp`,无 landing-page flash
+4. 同样 SPA 也支持 `innoseed.club/minicamp` 直接访问(供主站分享用)
+5. 内容由 [`src/pages/MiniCamp.tsx`](./src/pages/MiniCamp.tsx) 渲染,数据源在 [`src/content/site.ts`](./src/content/site.ts) 的 `MINICAMP` 块,沿用 PILLARS 的 4 色 accent 给产品/技术/设计/创业四路上色
+6. 子域名下用极简 chrome(`SubdomainHeader` / `SubdomainFooter`),主站下走完整 `Nav` + `Footer`
 
 ## 飞书 Bitable 接入 (招新表单持久化)
 

--- a/e2e/minicamp.spec.js
+++ b/e2e/minicamp.spec.js
@@ -1,0 +1,55 @@
+import { test, expect } from '@playwright/test';
+
+/**
+ * Mini Camp page (`/minicamp`) — `minicamp.innoseed.club` 子域名页。
+ *
+ * 路由表里 `/minicamp` 是新加的一条;SPA 里这条路由同时也是子域名根路径
+ * 的着陆点(由 App.tsx 在 hostname 检测后同步 Navigate 过来)。
+ *
+ * 这些断言仅覆盖页面结构和内容渲染 — 域名跳转的 host-aware 逻辑在
+ * 浏览器里靠 window.location.hostname 触发,无法在 e2e 里直接测。
+ */
+
+test.describe('minicamp @ /minicamp route', () => {
+  test.use({ viewport: { width: 1280, height: 900 } });
+
+  test('renders the page header, tracks, past camp, timeline, and CTA', async ({ page }) => {
+    await page.goto('/minicamp');
+    await expect(page.locator('.minicamp-page')).toBeVisible();
+
+    // Hero / page-header
+    await expect(page.locator('.minicamp-page .page-header h1')).toBeVisible();
+    // Eyebrow + breadcrumb carry the "Mini Camp" branding; the H1 holds the
+    // Chinese headline.
+    await expect(page.locator('.minicamp-page .eyebrow').first()).toContainText('Mini Camp');
+
+    // 4 tracks render — one card per pillar accent
+    const tracks = page.locator('.minicamp-track');
+    await expect(tracks).toHaveCount(4);
+    await expect(tracks.first()).toContainText('产品');
+    await expect(tracks.nth(1)).toContainText('技术');
+    await expect(tracks.nth(2)).toContainText('设计');
+    await expect(tracks.nth(3)).toContainText('创业');
+
+    // Past Mini Camp recap block
+    await expect(page.locator('.minicamp-past')).toBeVisible();
+    await expect(page.locator('.minicamp-past h2')).toContainText('2025 秋季 Mini Camp');
+
+    // Timeline 4 steps
+    const steps = page.locator('.minicamp-timeline-step');
+    await expect(steps).toHaveCount(4);
+
+    // Bottom CTA leads to /apply
+    const applyLink = page.locator('.minicamp-cta a[href="/apply"]').first();
+    await expect(applyLink).toBeVisible();
+    await expect(applyLink).toHaveAttribute('href', '/apply');
+  });
+
+  test('on the main domain the page shows full Nav (not subdomain chrome)', async ({ page }) => {
+    await page.goto('/minicamp');
+    // The full Nav renders the link row
+    await expect(page.locator('header nav a[href="#pillars"]')).toBeVisible();
+    // Subdomain-only chrome should NOT be present
+    await expect(page.locator('.minicamp-subdomain-head')).toHaveCount(0);
+  });
+});

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:headed": "playwright test --headed",
     "test:e2e:install": "playwright install chromium",
-    "test:tag-codes": "node scripts/test-tag-codes.mjs"
+    "test:tag-codes": "node scripts/test-tag-codes.mjs",
+    "verify:subdomain": "node scripts/verify-subdomain.mjs"
   },
   "dependencies": {
     "react": "^18.3.1",

--- a/scripts/verify-subdomain.mjs
+++ b/scripts/verify-subdomain.mjs
@@ -1,0 +1,236 @@
+#!/usr/bin/env node
+/**
+ * scripts/verify-subdomain.mjs — 在本地验证子域路由(host-aware redirect)
+ *
+ * 背景:
+ *   - 子域名(如 `minicamp.innoseed.club`)走的是同一份 Vite SPA
+ *   - 根路径 / 上有 hostname 检测,匹配子域名前缀就 `<Navigate>` 到
+ *     `/minicamp`,避免 landing 闪烁
+ *   - `e2e/minicamp.spec.js` 只能验页面结构 / 渲染,验不了 host 检测
+ *     (浏览器永远只能去一个真实 hostname,而真域名要 DNS)
+ *
+ * 这个脚本绕过 DNS:用 Chromium 的 `--host-resolver-rules` 把
+ * `minicamp.innoseed.club` 映射到 127.0.0.1,然后启动 `vite preview`
+ * 服务同一份 dist/,在浏览器里检查:
+ *
+ *   1.  子域根 /            → 重定向到 /minicamp,渲染子域 chrome
+ *   2.  子域 /apply          → 仍然落到招新表单
+ *   3.  主域根 /             → 渲染落地页(没重定向)
+ *   4.  主域 /minicamp       → 渲染 Mini Camp 页(完整 Nav,不子域 chrome)
+ *
+ * Prereq:
+ *   pnpm build                            # 生成 dist/
+ *
+ * Usage:
+ *   node scripts/verify-subdomain.mjs              # 自动启停 vite preview
+ *   VITE_PREVIEW_URL=http://host:8765 node ...     # 复用已起的服务器
+ *
+ * Exit codes:
+ *   0  — 全部通过
+ *   1  — 任一断言失败
+ *   2  — 启动 / 连接错误
+ */
+
+// ── 配置 ────────────────────────────────────────────────────────────
+
+import { spawn } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = fileURLToPath(new URL('.', import.meta.url));
+const ROOT = resolve(__dirname, '..');
+
+const SUBDOMAIN = 'minicamp.innoseed.club';
+const PORT = Number(process.env.PORT ?? 8765);
+const EXTERNAL_URL = process.env.VITE_PREVIEW_URL; // 跳过自启服务器
+
+// ── 检查 dist/ ─────────────────────────────────────────────────────
+
+if (!EXTERNAL_URL && !existsSync(resolve(ROOT, 'dist/index.html'))) {
+  console.error('✘ dist/index.html 不存在。先跑 pnpm build。');
+  process.exit(2);
+}
+
+// ── 解析 playwright-core ──────────────────────────────────────────
+//
+// 项目只装了 @playwright/test(测试运行时),没用 playwright / playwright-core
+// 作为顶层 dep。这里通过 pnpm 的真实 node_modules 路径拿到,
+// 不引新 dep。
+
+function resolvePlaywright() {
+  const pnpmPath = resolve(
+    ROOT,
+    'node_modules/.pnpm/playwright-core@1.61.1/node_modules/playwright-core/index.js',
+  );
+  if (existsSync(pnpmPath)) {
+    return import(pnpmPath);
+  }
+  throw new Error('找不到 playwright-core。先跑 pnpm install。');
+}
+
+// ── 启动 vite preview ─────────────────────────────────────────────
+
+function startVitePreview() {
+  // 用一个临时的"允许所有 host"配置,绕开 vite 5 默认的 Host header 校验。
+  // 生产里 Vercel 是这一层的正确边界,本地验证为了方便直接放行。
+  const cfgPath = resolve(ROOT, 'vite.verify-subdomain.config.ts');
+  if (!existsSync(cfgPath)) {
+    console.error(`✘ 缺少 ${cfgPath}。`);
+    process.exit(2);
+  }
+  const proc = spawn(
+    'npx',
+    [
+      'vite',
+      'preview',
+      '--config', cfgPath,
+      '--port', String(PORT),
+      '--host', '127.0.0.1',
+    ],
+    {
+      cwd: ROOT,
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: { ...process.env, FORCE_COLOR: '0' },
+    },
+  );
+  return proc;
+}
+
+async function waitForServer(url, timeoutMs = 8000) {
+  const start = Date.now();
+  while (Date.now() - start < timeoutMs) {
+    try {
+      const r = await fetch(url, { method: 'HEAD' });
+      if (r.ok || r.status === 405) return; // 405 = server alive, method not allowed
+    } catch { /* not yet */ }
+    await new Promise((r) => setTimeout(r, 200));
+  }
+  throw new Error(`server at ${url} did not respond within ${timeoutMs}ms`);
+}
+
+// ── 主测试 ────────────────────────────────────────────────────────
+
+async function runChecks() {
+  // playwright-core 用 CJS,import 拿到的是 default = 全模块 namespace
+  const pwModule = await resolvePlaywright();
+  const { chromium } = pwModule.default ?? pwModule;
+  const browser = await chromium.launch({
+    args: [
+      // 把子域名映射到本机。这样 URL 仍是 `minicamp.innoseed.club`,
+      // 但流量落到 127.0.0.1,window.location.hostname 也是前者。
+      '--host-resolver-rules=MAP ' + SUBDOMAIN + ' 127.0.0.1',
+      // 关掉 Chromium 的内置代理 — 它会干扰 vite preview 的 Host 校验,
+      // 返回莫名其妙的 502(空 body)。两个 flag 一起才生效。
+      '--no-proxy-server',
+      '--proxy-server=direct://',
+    ],
+  });
+
+  const ctx = await browser.newContext();
+  const page = await ctx.newPage();
+
+  const results = {};
+
+  // 1) 子域根 / → 重定向到 /minicamp
+  await page.goto(`http://${SUBDOMAIN}:${PORT}/`, { waitUntil: 'networkidle' });
+  // React Router 的同步 <Navigate> 会立刻跳到 /minicamp,但 chunk 是 lazy
+  // 加载的。等 .minicamp-track 出现再断言 H1 / chrome。
+  await page.locator('.minicamp-track').first().waitFor({ timeout: 5000 }).catch(() => {});
+  results.subdomain_root = {
+    finalUrl: page.url(),
+    h1Visible: await page.locator('.minicamp-page .page-header h1').isVisible(),
+    subdomainHeader: (await page.locator('.minicamp-subdomain-head').count()) === 1,
+    tracks: await page.locator('.minicamp-track').count(),
+    timelineSteps: await page.locator('.minicamp-timeline-step').count(),
+    ok: false,
+  };
+  results.subdomain_root.ok =
+    results.subdomain_root.finalUrl.endsWith('/minicamp') &&
+    results.subdomain_root.h1Visible &&
+    results.subdomain_root.subdomainHeader &&
+    results.subdomain_root.tracks === 4 &&
+    results.subdomain_root.timelineSteps === 4;
+
+  // 2) 子域 /apply → 仍然落到招新表单(不被重定向劫持)
+  await page.goto(`http://${SUBDOMAIN}:${PORT}/apply`, { waitUntil: 'networkidle' });
+  await page.getByText('欢迎加入 InnOSeed。').waitFor({ timeout: 5000 }).catch(() => {});
+  results.subdomain_apply = {
+    finalUrl: page.url(),
+    guideVisible: await page.getByText('欢迎加入 InnOSeed。').isVisible(),
+    ok: page.url().endsWith('/apply'),
+  };
+
+  // 3) 主域根 / → 落地页(没重定向)
+  await page.goto(`http://127.0.0.1:${PORT}/`, { waitUntil: 'networkidle' });
+  await page.locator('.hero h1').waitFor({ timeout: 5000 }).catch(() => {});
+  results.main_root = {
+    finalUrl: page.url(),
+    landingHeroVisible: await page.locator('.hero h1').isVisible(),
+    ok: page.url().endsWith('/') && (await page.locator('.hero h1').isVisible()),
+  };
+
+  // 4) 主域 /minicamp → 渲染 + 完整 Nav(不是子域 chrome)
+  await page.goto(`http://127.0.0.1:${PORT}/minicamp`, { waitUntil: 'networkidle' });
+  await page.locator('.minicamp-track').first().waitFor({ timeout: 5000 }).catch(() => {});
+  results.main_minicamp = {
+    finalUrl: page.url(),
+    fullNav: (await page.locator('header nav a[href="#pillars"]').count()) === 1,
+    noSubdomainChrome: (await page.locator('.minicamp-subdomain-head').count()) === 0,
+    ok: false,
+  };
+  results.main_minicamp.ok =
+    results.main_minicamp.fullNav && results.main_minicamp.noSubdomainChrome;
+
+  await browser.close();
+  return results;
+}
+
+// ── 输出 + 退出码 ──────────────────────────────────────────────────
+
+function fmt(ok) { return ok ? '\x1b[32m✓\x1b[0m' : '\x1b[31m✘\x1b[0m'; }
+
+async function main() {
+  let viteProc = null;
+  if (!EXTERNAL_URL) {
+    console.log(`▸ 启动 vite preview on 127.0.0.1:${PORT}`);
+    viteProc = startVitePreview();
+    viteProc.stderr.on('data', (d) => {
+      const msg = d.toString();
+      // vite 启动失败时 stderr 会有用
+      if (/error|EADDRINUSE/i.test(msg)) process.stderr.write(`[vite] ${msg}`);
+    });
+    await waitForServer(`http://127.0.0.1:${PORT}/`);
+  } else {
+    console.log(`▸ 复用外部服务器 ${EXTERNAL_URL}`);
+  }
+
+  let results;
+  try {
+    results = await runChecks();
+  } catch (e) {
+    console.error('✘ 测试运行失败:', e.message);
+    if (viteProc) viteProc.kill('SIGKILL');
+    process.exit(2);
+  }
+
+  if (viteProc) viteProc.kill('SIGKILL');
+
+  console.log('');
+  for (const [name, r] of Object.entries(results)) {
+    console.log(`${fmt(r.ok)} ${name}`);
+    if (!r.ok || process.env.VERBOSE) {
+      for (const [k, v] of Object.entries(r)) {
+        if (k === 'ok') continue;
+        console.log(`    ${k}: ${JSON.stringify(v)}`);
+      }
+    }
+  }
+
+  const allOk = Object.values(results).every((r) => r.ok);
+  console.log('');
+  console.log(allOk ? '✓ subdomain 路由验证通过' : '✘ 有断言失败');
+  process.exit(allOk ? 0 : 1);
+}
+
+main();

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,5 @@
 import { lazy, Suspense, useRef } from 'react';
-import { BrowserRouter, Routes, Route } from 'react-router-dom';
+import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import Nav from './components/Nav';
 import Hero from './components/Hero';
 import Organization from './components/SEO/Organization';
@@ -57,6 +57,7 @@ const Footer = lazy(() => import('./components/Footer'));
 const Apply = lazy(() => import('./pages/Apply'));
 const EventsPage = lazy(() => import('./pages/Events'));
 const RecruitPage = lazy(() => import('./pages/Recruit'));
+const MiniCampPage = lazy(() => import('./pages/MiniCamp'));
 const NotFound = lazy(() => import('./pages/NotFound'));
 
 /**
@@ -146,25 +147,43 @@ export default function App() {
           }
         />
         <Route
+          path="/minicamp"
+          element={
+            <Suspense fallback={<PageFallback />}>
+              <MiniCampPage />
+            </Suspense>
+          }
+        />
+        <Route
           path="/"
           element={
-            <>
-              <Nav />
-              <main id="main" ref={mainRef} tabIndex={-1}>
-                <Hero />
-                <Suspense fallback={null}>
-                  <Marquee />
-                  <Manifesto />
-                  <Pillars />
-                  <Numbers />
-                  <Members />
-                  <Inside />
-                  <Events />
-                  <Recruit />
-                  <Footer />
-                </Suspense>
-              </main>
-            </>
+            // Subdomain detection — when served from `minicamp.<root>`,
+            // route root directly to /minicamp so the URL stays shareable
+            // (minicamp.innoseed.club/minicamp) and the dedicated page
+            // renders. Other subdomains (or the main domain) get the
+            // landing page as usual. Done synchronously before render so
+            // there's no landing-page flash on subdomain root.
+            typeof window !== 'undefined' && window.location.hostname.startsWith('minicamp.') ? (
+              <Navigate to="/minicamp" replace />
+            ) : (
+              <>
+                <Nav />
+                <main id="main" ref={mainRef} tabIndex={-1}>
+                  <Hero />
+                  <Suspense fallback={null}>
+                    <Marquee />
+                    <Manifesto />
+                    <Pillars />
+                    <Numbers />
+                    <Members />
+                    <Inside />
+                    <Events />
+                    <Recruit />
+                    <Footer />
+                  </Suspense>
+                </main>
+              </>
+            )
           }
         />
         <Route

--- a/src/content/site.ts
+++ b/src/content/site.ts
@@ -510,3 +510,81 @@ export const RECRUIT_EXTRAS: RecruitExtras = {
     },
   ],
 };
+
+/**
+ * MiniCamp — `minicamp.innoseed.club` 子域名的内容源
+ *
+ * 这个页面复用 PILLARS 的 4 色 accent (compete/research/startup/bonds) 给
+ * 4 个分路上色,以及 EVENTS / RECRUIT_EXTRAS 中已有的 Mini Camp 素材。
+ *
+ * 域名检测在 MiniCamp.tsx 里做;此处只关心内容。
+ */
+export interface MiniCampTrack {
+  /** 与 PillarKey 一致 — 复用 4 色 token */
+  pillarKey: 'compete' | 'research' | 'startup' | 'bonds';
+  /** 序号,1-based */
+  index: number;
+  /** 分路名(显示) */
+  name: string;
+  /** 一句概括 */
+  one: string;
+  /** 详细说明 */
+  desc: string;
+}
+
+export interface MiniCampData {
+  eyebrow: string;
+  /** 主标题两行:lead + accent(em) */
+  headline: { lead: string; accent: string };
+  /** hero 下面的引导段 */
+  lead: string;
+  /** 正文段落(可含简单 HTML,如 <strong>) */
+  paragraphs: string[];
+  /** 4 个分路 */
+  tracks: MiniCampTrack[];
+  /** CTA 按钮(指 /apply) */
+  cta: HeroCta;
+}
+
+export const MINICAMP: MiniCampData = {
+  eyebrow: 'Mini Camp · InnOSeed 招新',
+  headline: { lead: '一个白天的', accent: '招新。' },
+  lead:
+    'InnOSeed 招新不做宣讲、不做群面——候选人和我们聚到一起，一个白天做完事。这是 Mini Camp。',
+  paragraphs: [
+    '候选人按 <strong>产品 / 技术 / 设计 / 创业</strong> 四路分头，每路 2-3 人自由组队。',
+    '一个白天的产出：原型 + 现场 Demo + 当场反馈。我们看的不是"做完了什么"，而是"怎么想的、怎么表达的、怎么和队友合作的"。',
+    'Mini Camp 是 InnOSeed 招新流程的核心——它是判断"能不能一起做事"的最终环节。',
+  ],
+  tracks: [
+    {
+      pillarKey: 'compete',
+      index: 1,
+      name: '产品',
+      one: '定义要解决的问题。',
+      desc: '从用户场景出发，写一句话问题，列 3 条假设，画一张草图。你来定义这个白天到底要做什么。',
+    },
+    {
+      pillarKey: 'research',
+      index: 2,
+      name: '技术',
+      one: '把原型跑起来。',
+      desc: '不要求代码多漂亮。能用最直接的方式证明"这个东西确实能跑"就够了——贴一个 demo URL 或者一段录屏即可。',
+    },
+    {
+      pillarKey: 'startup',
+      index: 3,
+      name: '设计',
+      one: '把体验做顺。',
+      desc: '信息架构、关键页面的视觉稿、用户路径。你不需要是设计师，但需要能把"用户怎么走完这件事"讲清楚。',
+    },
+    {
+      pillarKey: 'bonds',
+      index: 4,
+      name: '创业',
+      one: '把想法推到市场前。',
+      desc: '想清楚目标用户是谁、怎么触达、第一次验证怎么做。可以是一段客户访谈、一份落地页、或者一个 landing。',
+    },
+  ],
+  cta: { label: '立即申请 · Apply Now', arrow: '→', href: '/apply' },
+};

--- a/src/pages/Apply.tsx
+++ b/src/pages/Apply.tsx
@@ -385,7 +385,8 @@ function DoneStep({
       <span className="eyebrow">04 — Done</span>
       <h1>你的个性标签已生成。</h1>
       <p className="apply-lead">
-        复制下面的代码保存下来，作为后续 InnOSeed 联系 / 群组匹配的引用 ID
+        复制下面的代码保存下来——打开下方"飞书表单"，把它粘到表单里的
+        <strong>「个性标签」字段</strong>，再上传简历
         {interviewer && <>。你选的面聊官是 <strong>{interviewer.code}</strong>。</>}
       </p>
 
@@ -412,9 +413,11 @@ function DoneStep({
       </div>
 
       <div className="apply-callout">
-        <h2>下一步 — 投递简历</h2>
+        <h2>下一步 — 把标签粘到飞书表单 + 投递简历</h2>
         <p>
-          个性标签生成完成，接下来请把简历投到飞书表单（必填，InnOSeed 通过简历 + 标签做综合评估）。
+          <strong>必填</strong>：把上面那份『个性标签代码』粘到飞书表单的
+          <strong>「个性标签」字段</strong>，再上传简历。
+          InnOSeed 通过简历 + 标签做综合评估——标签是面试官匹配 / 群组分配的依据。
           飞书表单提交后我们会尽快与你联系。
         </p>
         <a
@@ -423,7 +426,7 @@ function DoneStep({
           target="_blank"
           rel="noopener"
         >
-          投递简历 (飞书表单) ↗
+          打开飞书表单 ↗
         </a>
       </div>
     </section>

--- a/src/pages/MiniCamp.css
+++ b/src/pages/MiniCamp.css
@@ -1,0 +1,350 @@
+/* =========================================================
+   Mini Camp page — `minicamp.innoseed.club` 子域页面
+   与主站共 design token(--c-compete/research/startup/bonds)。
+   ========================================================= */
+
+.minicamp-page {
+  background: var(--bg-cream);
+  color: var(--ink-dark);
+  font-family: var(--ff-sans);
+}
+
+/* ── Hero CTA row ─────────────────────────────────────────── */
+
+.minicamp-hero-cta {
+  margin-top: 32px;
+  display: flex;
+  gap: 16px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+/* ── Subdomain chrome (minicamp.innoseed.club 头/尾) ───────── */
+
+.minicamp-subdomain-head {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: rgba(247, 245, 239, 0.92);
+  backdrop-filter: blur(14px) saturate(140%);
+  -webkit-backdrop-filter: blur(14px) saturate(140%);
+  border-bottom: 1px solid var(--rule);
+}
+.minicamp-subdomain-head .container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding-top: 14px;
+  padding-bottom: 14px;
+  gap: 16px;
+}
+.minicamp-subdomain-brand {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 10px;
+  font-family: var(--ff-zh);
+  font-weight: 600;
+  letter-spacing: 0.04em;
+  color: var(--ink-dark);
+  text-decoration: none;
+}
+.minicamp-subdomain-mark {
+  color: var(--c-research);
+  font-size: 14px;
+  position: relative;
+  top: -1px;
+}
+.minicamp-subdomain-name {
+  font-size: 16px;
+}
+.minicamp-subdomain-of {
+  font-size: 12px;
+  color: var(--ink-muted);
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+.minicamp-subdomain-back {
+  font-size: 13px;
+  color: var(--ink-mid);
+  padding: 8px 14px;
+  border-radius: 999px;
+  border: 1px solid var(--rule);
+  background: var(--bg-base);
+  text-decoration: none;
+  transition: border-color 0.2s ease, color 0.2s ease;
+}
+.minicamp-subdomain-back:hover {
+  border-color: var(--brand);
+  color: var(--ink-dark);
+}
+
+.minicamp-subdomain-foot {
+  border-top: 1px solid var(--rule);
+  padding: 32px 0;
+  font-size: 13px;
+  color: var(--ink-muted);
+}
+.minicamp-subdomain-foot .container {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 16px;
+  flex-wrap: wrap;
+}
+.minicamp-subdomain-foot a {
+  color: var(--ink-mid);
+}
+.minicamp-subdomain-foot a:hover {
+  color: var(--ink-dark);
+}
+
+/* ── Lead paragraphs ──────────────────────────────────────── */
+
+.minicamp-section {
+  padding: clamp(48px, 8vw, 96px) 0;
+  border-top: 1px solid var(--rule);
+}
+.minicamp-paragraphs {
+  max-width: 720px;
+  font-family: var(--ff-zh);
+  font-size: clamp(15px, 1.4vw, 18px);
+  line-height: 1.85;
+  color: var(--ink-mid);
+}
+.minicamp-paragraphs p + p {
+  margin-top: 1em;
+}
+.minicamp-paragraphs strong {
+  color: var(--ink-dark);
+  font-weight: 600;
+}
+
+/* ── 4 tracks grid ────────────────────────────────────────── */
+
+.minicamp-tracks {
+  padding: clamp(64px, 10vw, 120px) 0;
+  background: var(--bg-base);
+  border-top: 1px solid var(--rule);
+}
+.minicamp-tracks h2 {
+  margin-top: 8px;
+  font-family: var(--ff-zh-serif);
+  font-size: clamp(26px, 3vw, 40px);
+  line-height: 1.2;
+  color: var(--ink-dark);
+}
+.minicamp-tracks h2 em {
+  font-style: italic;
+  color: var(--c-research);
+}
+.minicamp-track-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(260px, 1fr));
+  gap: 18px;
+  margin-top: 40px;
+}
+.minicamp-track {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+  padding: 28px 24px 24px;
+  background: var(--bg-cream);
+  border: 1px solid var(--rule);
+  border-radius: var(--radius-md);
+  overflow: hidden;
+  transition: transform 0.25s ease, box-shadow 0.25s ease;
+}
+.minicamp-track::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 3px;
+  background: var(--track-color, var(--ink-faint));
+}
+.minicamp-track.pillar-compete { --track-color: var(--c-compete); }
+.minicamp-track.pillar-research { --track-color: var(--c-research); }
+.minicamp-track.pillar-startup { --track-color: var(--c-startup); }
+.minicamp-track.pillar-bonds { --track-color: var(--c-bonds); }
+.minicamp-track:hover {
+  transform: translateY(-4px);
+  box-shadow: 0 14px 30px -18px rgba(15, 23, 42, 0.18);
+}
+.minicamp-track-head {
+  display: inline-flex;
+  align-items: baseline;
+  gap: 12px;
+}
+.minicamp-track-num {
+  font-family: var(--ff-display);
+  font-style: italic;
+  font-size: 14px;
+  color: var(--track-color);
+  letter-spacing: 0.05em;
+}
+.minicamp-track-name {
+  font-family: var(--ff-zh-serif);
+  font-weight: 700;
+  font-size: 22px;
+  color: var(--ink-dark);
+}
+.minicamp-track-one {
+  font-family: var(--ff-zh);
+  font-size: 15px;
+  color: var(--ink-dark);
+  line-height: 1.5;
+}
+.minicamp-track-desc {
+  font-size: 13px;
+  color: var(--ink-muted);
+  line-height: 1.7;
+}
+
+/* ── Past Mini Camp recap ─────────────────────────────────── */
+
+.minicamp-past {
+  padding: clamp(64px, 10vw, 120px) 0;
+  border-top: 1px solid var(--rule);
+}
+.minicamp-past h2 {
+  margin-top: 8px;
+  font-family: var(--ff-zh-serif);
+  font-size: clamp(24px, 2.6vw, 34px);
+  line-height: 1.3;
+  color: var(--ink-dark);
+}
+.minicamp-past h2 em {
+  font-style: italic;
+  color: var(--c-research);
+}
+.minicamp-past-subtitle {
+  margin-top: 12px;
+  font-family: var(--ff-zh);
+  font-size: 15px;
+  color: var(--ink-mid);
+  letter-spacing: 0.04em;
+}
+.minicamp-past-body {
+  margin-top: 20px;
+  max-width: 720px;
+  font-size: 15px;
+  line-height: 1.85;
+  color: var(--ink-mid);
+}
+.minicamp-past-where {
+  margin-top: 16px;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 13px;
+  color: var(--ink-muted);
+}
+.minicamp-past-where svg {
+  width: 14px;
+  height: 14px;
+}
+
+/* ── Timeline (4 步) ──────────────────────────────────────── */
+
+.minicamp-timeline {
+  padding: clamp(64px, 10vw, 120px) 0;
+  background: var(--bg-base);
+  border-top: 1px solid var(--rule);
+}
+.minicamp-timeline h2 {
+  margin-top: 8px;
+  font-family: var(--ff-zh-serif);
+  font-size: clamp(26px, 3vw, 40px);
+  line-height: 1.2;
+  color: var(--ink-dark);
+}
+.minicamp-timeline h2 em {
+  font-style: italic;
+  color: var(--c-research);
+}
+.minicamp-timeline-list {
+  list-style: none;
+  padding: 0;
+  margin: 40px 0 0;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(240px, 1fr));
+  gap: 20px;
+}
+.minicamp-timeline-step {
+  position: relative;
+  padding: 22px 22px 22px 24px;
+  background: var(--bg-cream);
+  border: 1px solid var(--rule);
+  border-radius: var(--radius-md);
+  border-left: 4px solid var(--step-color, var(--ink-faint));
+}
+.minicamp-timeline-step.pillar-compete { --step-color: var(--c-compete); }
+.minicamp-timeline-step.pillar-research { --step-color: var(--c-research); }
+.minicamp-timeline-step.pillar-startup { --step-color: var(--c-startup); }
+.minicamp-timeline-step.pillar-bonds { --step-color: var(--c-bonds); }
+.minicamp-timeline-when {
+  display: block;
+  font-family: var(--ff-display);
+  font-style: italic;
+  font-size: 13px;
+  letter-spacing: 0.06em;
+  color: var(--step-color);
+  margin-bottom: 8px;
+}
+.minicamp-timeline-title {
+  font-family: var(--ff-zh-serif);
+  font-weight: 700;
+  font-size: 18px;
+  color: var(--ink-dark);
+  margin: 0 0 8px;
+}
+.minicamp-timeline-desc {
+  font-size: 13px;
+  line-height: 1.7;
+  color: var(--ink-muted);
+}
+
+/* ── Bottom CTA ───────────────────────────────────────────── */
+
+.minicamp-cta {
+  padding: clamp(64px, 10vw, 120px) 0;
+  border-top: 1px solid var(--rule);
+  background: var(--bg-cream);
+}
+.minicamp-cta h2 {
+  font-family: var(--ff-zh-serif);
+  font-size: clamp(26px, 3vw, 40px);
+  line-height: 1.2;
+  color: var(--ink-dark);
+  margin: 0 0 12px;
+}
+.minicamp-cta p {
+  max-width: 720px;
+  font-size: 15px;
+  line-height: 1.85;
+  color: var(--ink-mid);
+}
+.minicamp-cta-row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  align-items: center;
+  margin-top: 28px;
+}
+
+/* ── Mobile ───────────────────────────────────────────────── */
+
+@media (max-width: 720px) {
+  .minicamp-track-grid {
+    grid-template-columns: 1fr;
+  }
+  .minicamp-timeline-list {
+    grid-template-columns: 1fr;
+  }
+  .minicamp-subdomain-foot .container {
+    flex-direction: column;
+    align-items: flex-start;
+  }
+}

--- a/src/pages/MiniCamp.tsx
+++ b/src/pages/MiniCamp.tsx
@@ -1,0 +1,232 @@
+import { useEffect, useRef } from 'react';
+import { Link } from 'react-router-dom';
+import Nav from '../components/Nav';
+import Footer from '../components/Footer';
+import useReveal from '../hooks/useReveal';
+import usePageMeta from '../hooks/usePageMeta';
+import { MINICAMP, EVENTS, RECRUIT_EXTRAS, BRAND, CONTACT_EMAIL } from '../content/site';
+import './MiniCamp.css';
+
+/**
+ * MiniCamp — `minicamp.innoseed.club` 子域名页(同 SPA)。
+ *
+ * 设计思路:
+ *   - 同一个 Vite 部署包,同一份 vercel.json,只是 Vercel 在 Domains 里
+ *     多绑一个域名。当 hostname 以 `minicamp.` 开头时,根路径 /
+ *     由 App.tsx 的路由层重定向到 /minicamp,这样:
+ *       · minicamp.innoseed.club/         → 落到本页
+ *       · minicamp.innoseed.club/apply    → 落到 Apply 页(招新表单)
+ *       · innoseed.club/minicamp          → 主站也能直接分享这个 URL
+ *   - Chrome 自适应:子域名下用极简头(品牌 + 回主站);主站下用全 Nav,
+ *     保持一致导航体验。
+ *   - 内容沿用 PILLARS 的 4 色 accent 给 4 个分路上色,复用 EVENTS 中
+ *     上一届 Mini Camp 条目,以及 RECRUIT_EXTRAS.timeline 的 4 步招新
+ *     时间线 — 数据单源在 site.ts。
+ */
+
+function isMiniCampHost(): boolean {
+  if (typeof window === 'undefined') return false;
+  return window.location.hostname.startsWith('minicamp.');
+}
+
+export default function MiniCamp() {
+  const headRef = useRef<HTMLElement | null>(null);
+  useReveal(headRef);
+
+  // Scroll to top on mount — arriving from another route shouldn't keep
+  // the user mid-page from wherever they were before.
+  useEffect(() => {
+    window.scrollTo({ top: 0, behavior: 'instant' as ScrollBehavior });
+  }, []);
+
+  // Per-route SEO. Description 专为 Mini Camp 写,跟首页的简短描述区分。
+  usePageMeta({
+    title: 'Mini Camp · InnOSeed 招新',
+    description:
+      'InnOSeed 招新不做宣讲——一个白天的 Mini Camp,4 路分头(产品/技术/设计/创业)产出原型 + 现场 Demo + 当场反馈。这是 InnOSeed 招新流程的核心环节。',
+    canonical: '/minicamp',
+  });
+
+  const onSubdomain = isMiniCampHost();
+  const pastCamp = EVENTS.items.find((e) => e.key === 'mini-camp-fall-2025');
+
+  return (
+    <>
+      {onSubdomain ? <SubdomainHeader /> : <Nav />}
+      <main id="main" tabIndex={-1} className="minicamp-page">
+        <header ref={headRef} className="page-header reveal">
+          <div className="container">
+            <nav className="breadcrumb" aria-label="面包屑">
+              {onSubdomain ? (
+                <a href="https://innoseed.club">{BRAND} 主站</a>
+              ) : (
+                <Link to="/">首页</Link>
+              )}
+              <span aria-hidden="true">/</span>
+              <span aria-current="page">Mini Camp</span>
+            </nav>
+            <span className="eyebrow">{MINICAMP.eyebrow}</span>
+            <h1>
+              {MINICAMP.headline.lead} <em>{MINICAMP.headline.accent}</em>
+            </h1>
+            <p className="page-header-desc">{MINICAMP.lead}</p>
+            <div className="minicamp-hero-cta">
+              <Link to={MINICAMP.cta.href} className="btn btn-primary">
+                <span>{MINICAMP.cta.label}</span>
+                <span className="arrow">{MINICAMP.cta.arrow}</span>
+              </Link>
+            </div>
+          </div>
+        </header>
+
+        <section className="minicamp-section">
+          <div className="container">
+            <div className="minicamp-paragraphs">
+              {MINICAMP.paragraphs.map((html, i) => (
+                <p key={i} dangerouslySetInnerHTML={{ __html: html }} />
+              ))}
+            </div>
+          </div>
+        </section>
+
+        <section className="minicamp-tracks">
+          <div className="container">
+            <span className="eyebrow">四路分头</span>
+            <h2>
+              按你的<em>擅长</em>选一条路。
+            </h2>
+            <div className="minicamp-track-grid">
+              {MINICAMP.tracks.map((t) => (
+                <article
+                  key={t.pillarKey}
+                  className={`minicamp-track pillar-${t.pillarKey}`}
+                >
+                  <header className="minicamp-track-head">
+                    <span className="minicamp-track-num">
+                      0{t.index}
+                    </span>
+                    <span className="minicamp-track-name">{t.name}</span>
+                  </header>
+                  <p className="minicamp-track-one">{t.one}</p>
+                  <p className="minicamp-track-desc">{t.desc}</p>
+                </article>
+              ))}
+            </div>
+          </div>
+        </section>
+
+        {pastCamp && (
+          <section className="minicamp-past">
+            <div className="container">
+              <span className="eyebrow">上一届</span>
+              <h2>
+                <em>{pastCamp.date}</em> · {pastCamp.title}
+              </h2>
+              <p className="minicamp-past-subtitle">{pastCamp.subtitle}</p>
+              <p className="minicamp-past-body">{pastCamp.body}</p>
+              <p className="minicamp-past-where">
+                <svg
+                  viewBox="0 0 24 24"
+                  fill="none"
+                  stroke="currentColor"
+                  strokeWidth="1.6"
+                  aria-hidden="true"
+                >
+                  <path d="M12 2a8 8 0 0 0-8 8c0 5.5 8 12 8 12s8-6.5 8-12a8 8 0 0 0-8-8z" />
+                  <circle cx="12" cy="10" r="3" />
+                </svg>
+                {pastCamp.where}
+              </p>
+            </div>
+          </section>
+        )}
+
+        <section className="minicamp-timeline">
+          <div className="container">
+            <span className="eyebrow">招新流程</span>
+            <h2>
+              走到 Mini Camp 之前的<em>三步</em>。
+            </h2>
+            <ol className="minicamp-timeline-list">
+              {RECRUIT_EXTRAS.timeline.map((step) => (
+                <li
+                  key={step.index}
+                  className={`minicamp-timeline-step pillar-${step.phase}`}
+                >
+                  <span className="minicamp-timeline-when">{step.when}</span>
+                  <h3 className="minicamp-timeline-title">{step.title}</h3>
+                  <p className="minicamp-timeline-desc">{step.desc}</p>
+                </li>
+              ))}
+            </ol>
+          </div>
+        </section>
+
+        <section className="minicamp-cta">
+          <div className="container">
+            <h2>准备好来 Mini Camp 了?</h2>
+            <p>
+              填一份申请(几分钟),生成你的个性标签代码,
+              再到飞书表单提交简历 + 标签。我们 3 天内回复是否进入 Mini Camp。
+            </p>
+            <div className="minicamp-cta-row">
+              <Link to={MINICAMP.cta.href} className="btn btn-primary">
+                <span>{MINICAMP.cta.label}</span>
+                <span className="arrow">{MINICAMP.cta.arrow}</span>
+              </Link>
+              <a className="btn btn-ghost" href={`mailto:${CONTACT_EMAIL}`}>
+                联系我们: {CONTACT_EMAIL}
+              </a>
+            </div>
+          </div>
+        </section>
+      </main>
+      {onSubdomain ? <SubdomainFooter /> : <Footer />}
+    </>
+  );
+}
+
+/**
+ * SubdomainHeader — 子域名下的极简头
+ *
+ * 只显示品牌 + 回主站入口。不放 Nav,因为这是 Mini Camp 专用页,
+ * 让访客不被其他章节噪音干扰。
+ */
+function SubdomainHeader() {
+  return (
+    <header className="minicamp-subdomain-head">
+      <div className="container">
+        <a
+          className="minicamp-subdomain-brand"
+          href={typeof window !== 'undefined' ? window.location.href : '/'}
+        >
+          <span className="minicamp-subdomain-mark" aria-hidden="true">
+            ◉
+          </span>
+          <span className="minicamp-subdomain-name">Mini Camp</span>
+          <span className="minicamp-subdomain-of">of {BRAND}</span>
+        </a>
+        <a
+          className="minicamp-subdomain-back"
+          href={`https://${BRAND === 'InnOSeed' ? 'innoseed.club' : 'innoseed.club'}`}
+          aria-label={`返回 ${BRAND} 主站`}
+        >
+          ← 主站
+        </a>
+      </div>
+    </header>
+  );
+}
+
+function SubdomainFooter() {
+  return (
+    <footer className="minicamp-subdomain-foot">
+      <div className="container">
+        <span>
+          © {BRAND} Lab · Mini Camp 招新专用页
+        </span>
+        <a href={`mailto:${CONTACT_EMAIL}`}>{CONTACT_EMAIL}</a>
+      </div>
+    </footer>
+  );
+}

--- a/vite.verify-subdomain.config.ts
+++ b/vite.verify-subdomain.config.ts
@@ -1,0 +1,26 @@
+// One-shot verifier config — inherits from vite.config.ts and opens the
+// preview server's Host header check so curl / chromium can hit
+// `minicamp.innoseed.club:8765` against 127.0.0.1.
+//
+// NOT for production. Production is served by Vercel, which is the right
+// layer to enforce Host policies.
+//
+// Usage: pnpm exec vite preview --config vite.verify-subdomain.config.ts --port 8765
+import config from './vite.config';
+
+export default {
+  ...config,
+  preview: {
+    ...(config.preview ?? {}),
+    host: '127.0.0.1',
+    port: 8765,
+    // Vite 5+ rejects requests whose Host header doesn't match the bound
+    // address. We're testing the in-app hostname detection, so we need
+    // `minicamp.innoseed.club` to be accepted.
+    //
+    // `true` is the Vite-doc way to disable the check entirely for a
+    // local verifier; we're not exposing this to anything but our test
+    // browser, so an over-broad allow is fine.
+    allowedHosts: true,
+  },
+};


### PR DESCRIPTION
## What

Two changes:

### 1. minicamp.innoseed.club subdomain (dedicated Mini Camp page)
- New `/minicamp` route + `pages/MiniCamp.tsx` (focused Mini Camp landing: 4 tracks, past camp recap, recruit timeline, CTA → `/apply`).
- `src/App.tsx`: hostname-aware `<Navigate>` at `/` — when `window.location.hostname.startsWith('minicamp.')`, synchronously redirects to `/minicamp` (no landing-page flash).
- Same SPA, multiple Vercel domains — no new project, just add `minicamp.innoseed.club` in Vercel → Domains + DNS CNAME.
- Subdomain chrome (`SubdomainHeader` / `SubdomainFooter`, brand + back-to-main link) on the subdomain; full `Nav` + `Footer` on the main domain. `MiniCamp` is its own lazy chunk (~5KB JS + 6KB CSS), not pulled into the landing bundle.
- `scripts/verify-subdomain.mjs` + `vite.verify-subdomain.config.ts`: local verifier using Chromium `--host-resolver-rules` (no `/etc/hosts` edit, no sudo) — exercises the host-redirect that `e2e/minicamp.spec.js` can't. `pnpm verify:subdomain`.
- `vite.verify-subdomain.config.ts` opens the vite preview Host header check for testing only (production is served by Vercel, where this concern doesn't exist).

### 2. Apply Done-step copy
- Lead explicitly says "open the Feishu form below, paste the code into the 个性标签 field" — fixes the previous implicit callout.
- Callout h2: 下一步 — 把标签粘到飞书表单 + 投递简历.
- Callout body marks 个性标签 as 必填 and names the Feishu field. Button text: 打开飞书表单 ↗.
- `apply.spec.js` still passes (callout still contains 投递简历).

## Verified locally

- `pnpm typecheck && pnpm build && pnpm test:e2e && pnpm test:tag-codes` — 39 e2e + 25 tag-code tests green.
- `pnpm verify:subdomain` — all 4 subdomain assertions green:
  - `minicamp.innoseed.club/` → redirects to `/minicamp`, renders subdomain chrome (header + footer), 4 tracks, 4 timeline steps.
  - `minicamp.innoseed.club/apply` → still lands on Apply (not hijacked).
  - `127.0.0.1:8765/` → landing page (no redirect).
  - `127.0.0.1:8765/minicamp` → Mini Camp page with full `Nav` (not subdomain chrome).

## Docs
- `README.md` site map + 子域名 section with Vercel / DNS steps.
- `AGENTS.md` routing contract updated.

## Chore
- `.gitignore`: ignore `src/content/site.js` + `site.d.ts` (composite-emitted by `tsconfig.node.json`).

## Deploy

Once merged, CI auto-deploys. To make the subdomain reachable, after merge:
1. Vercel dashboard → `innoseed-landing` → Settings → Domains → add `minicamp.innoseed.club`.
2. DNS provider: CNAME `minicamp` → `cname.vercel-dns.com` (Cloudflare: `DNS only`).
3. Verify: visit `https://minicamp.innoseed.club/` → should land on Mini Camp page; `https://innoseed.club/minicamp` should also work (main domain path).