### PR TITLE
feat(hero): 扫光效果：琥珀色填充 + 黑色虚线描边

### DIFF
--- a/spec.md
+++ b/spec.md
@@ -115,6 +115,7 @@ v3 阶段放弃了原 spec 里的 video-led hero（macro time-lapse 种子萌芽
 | `--c-research` | `#166534` | 深绿（科研 pillar + 国家荣誉数字 + Recruit CTA） |
 | `--c-startup` | `#1E40AF` | 蓝（创业 pillar） |
 | `--c-bonds` | `#991B1B` | 红（志合者 pillar） |
+| `--accent-amber` | `#D97706` | 琥珀（Hero headline 扫光高亮色 + skip-link focus 描边） |
 
 ---
 
@@ -143,6 +144,7 @@ v4 引入明确的三档移动端断点（v3 散落在 520/720/760/880/920/980px
 | Nav scrolled 切换 | scroll > 60px | 0.4s ease |
 | Pillar hover 上浮 | mouseover | 0.5s |
 | Hero parallax | scroll (≥720px) | rAF 节流，translateY 0.25× scroll |
+| Hero headline 扫光 | mouseover (桌面 `(hover:hover) and (pointer:fine)`) | rAF 节流，--sweep-y → overlay 的 `clip-path: inset()` 露顶，被扫过的字变 `--accent-amber`；触屏 / prefers-reduced-motion 关闭 |
 | 滚动指示下落 | 无限循环 | 2.2s scaleY 1→0.4 |
 | Marquee | 无限循环 | 36s linear translateX |
 

--- a/src/components/Hero.module.css
+++ b/src/components/Hero.module.css
@@ -1,0 +1,210 @@
+/* Hero — headline sweep-light with dashed amber outline.
+ *
+ * Moved out of globals.css (Aug 2025) into a CSS Module so the sweep
+ * effect is fully encapsulated: the dashed amber outline, the
+ * dual-layer clip-path trick, and the row rise-in animation are all
+ * owned by Hero and don't leak into globals.css's selector space.
+ *
+ * The sweep-light uses two stacked copies of the same rows:
+ *   - Base layer: normal static headline — ink-dark text + brand-blue
+ *     accent em. Pure HTML `<span>`s so screen readers, SEO, and
+ *     text selection work as usual.
+ *   - Overlay layer: an SVG `<text>` carrying the same glyphs with
+ *     `fill: transparent` and a `stroke-dasharray` amber outline. SVG
+ *     is the only way to get real per-glyph dashed strokes — CSS's
+ *     `-webkit-text-stroke` does not honor `stroke-dasharray`. Because
+ *     the SVG fill is transparent, the base layer's ink-dark text
+ *     shows through; only the dashed amber edge is visible, which
+ *     is the "速写本 dashed edge" effect over the swept area.
+ *
+ * Why amber `--accent-amber` instead of `--brand` for the outline:
+ *   The accent em "InnOSeed" is rendered in `--brand` on the base
+ *   layer; a `--brand` outline would be invisible against it. Amber
+ *   (#D97706) gives a clear warm/cool contrast against the cool blue
+ *   accent and the cool dark ink — the sweep reads instantly.
+ *
+ * Why the overlay is SVG `<text>` rather than two stacked `<span>`s:
+ *   We tried that first (an earlier draft) and the dashed effect
+ *   genuinely requires SVG `stroke-dasharray` — there's no CSS-only
+ *   way to render a dashed outline on a glyph.
+ *
+ * The overlay is `pointer-events: none` so it never intercepts
+ * hover/move events meant for the base layer or anything below it.
+ *
+ * `var(--sweep-y)` is driven by `src/hooks/useHeroSweep.ts`; the
+ * default value `0px` is declared inline on the `.headline` rule so
+ * the overlay's clip-path still resolves before JS hydrates.
+ *
+ * SVG / base alignment: the SVG overlay's `<text y="1em">` puts the
+ * first baseline at 1em from the SVG top, and each `<tspan dy="1em">`
+ * adds another 1em of baseline spacing — matching the base layer's
+ * `line-height: 1.0` HTML layout. Pixel-level glyph registration is
+ * good enough across Chrome / Safari / Firefox for the same font, but
+ * not perfect (CSS and SVG rendering pipelines are separate); the
+ * dashed outline being slightly offset from the underlying ink-dark
+ * glyph is visually fine — it reads as the intended "stroked" effect.
+ *
+ * The h1's own rules here only need a single `.headline` selector —
+ * globals.css used to carry a `.hero h1 { font-size: 20–32px }` rule
+ * (v3 era, when the hero had a separate lead-sentence h1) but that
+ * rule was removed: nothing in the current codebase matches it.
+ */
+
+.headline {
+  font-family: var(--ff-display);
+  font-weight: 800;
+  font-size: clamp(56px, 8vw, 128px);
+  line-height: 1.0;
+  letter-spacing: -0.035em;
+  color: var(--ink-dark);
+  margin: 10px 0 22px;
+  max-width: 1300px;
+  /* Holds the two stacked .layer children; the overlay positions
+     itself absolutely against this container. */
+  position: relative;
+  /* Default so the overlay's clip-path still resolves before JS
+     hydrates and before the cursor has entered the h1. */
+  --sweep-y: 0px;
+}
+
+.row {
+  display: block;
+  overflow: hidden;
+}
+.row > span {
+  display: inline-block;
+  transform: translateY(110%);
+  animation: heroRise 1.2s cubic-bezier(0.22, 1, 0.36, 1) forwards;
+}
+.row:nth-child(1) > span { animation-delay: 0.2s; }
+.row:nth-child(2) > span { animation-delay: 0.45s; }
+.row:nth-child(3) > span { animation-delay: 0.7s; }
+@keyframes heroRise { to { transform: translateY(0); } }
+
+/* Italic Fraunces for the Latin brand name "InnOSeed", weighted and
+   tinted brand-blue so it still reads as the visual anchor inside
+   the serif block. Same treatment as the section <em>s (Manifesto /
+   Pillars / Numbers / Members / Recruit / page-header h1). */
+.accent {
+  font-family: var(--ff-display);
+  font-style: italic;
+  font-weight: 800;
+  color: var(--brand);
+  letter-spacing: -0.04em;
+}
+
+.layer {
+  display: block;
+}
+.base {
+  color: var(--ink-dark);
+}
+
+/* SVG overlay: an SVG element positioned over the base layer, sized
+   to match the h1 box. It carries the dashed amber glyph outlines
+   that appear (via clip-path) wherever the cursor has swept. */
+.overlay {
+  position: absolute;
+  inset: 0;
+  /* SVG has intrinsic 300×150 dimensions; without explicit width/
+     height the element would be a small square in the corner of
+     the h1, with the dashed glyphs clipped beyond its right/bottom
+     edges. Force the SVG to fill the absolutely-positioned box. */
+  width: 100%;
+  height: 100%;
+  /* Reveal the top `--sweep-y` slice, clip the rest.
+     `calc(100% - var(--sweep-y))` is the bottom inset. When
+     --sweep-y is 0, the bottom inset equals 100%, so the overlay is
+     entirely clipped and invisible — the static headline is
+     unchanged. */
+  clip-path: inset(0 0 calc(100% - var(--sweep-y, 0px)) 0);
+  pointer-events: none;
+  user-select: none;
+  /* Hide the SVG dashed outline until the base layer's hero-rise
+     entry animation finishes — otherwise the dashed glyphs would
+     float in mid-air before the base text rises into place. */
+  opacity: 0;
+  animation: overlayIn 0.4s ease 1.55s forwards;
+}
+@keyframes overlayIn {
+  to { opacity: 1; }
+}
+
+/* SVG text styling. `fill: transparent` lets the base layer's
+   ink-dark text show through; only the dashed amber `stroke` is
+   visible. `paint-order: stroke fill` (the explicit two-value form)
+   keeps the dashed stroke crisply readable — without it, the
+   stroke would be drawn first and the (transparent) fill on top
+   would punch holes through the dashes. */
+.svgText {
+  font-family: var(--ff-display);
+  font-size: clamp(56px, 8vw, 128px);
+  font-weight: 800;
+  letter-spacing: -0.035em;
+  /* Two-color glyph effect for the swept area:
+       fill:  amber  — the same `--accent-amber` the original sweep
+                       used, so the swept region reads as a color
+                       change (matching the "scanned text changes
+                       color" behavior that was lost when we tried
+                       fill: transparent).
+       stroke: ink-dark + dashed  — a black dashed outline that
+                       sits on the glyph edges, on top of the amber
+                       fill (paint-order below). The dark stroke on
+                       warm amber gives the "sketched over" feel
+                       without losing the underlying color shift. */
+  fill: var(--accent-amber);
+  stroke: var(--ink-dark);
+  stroke-width: 1.2;
+  stroke-dasharray: 4 3;
+  paint-order: stroke fill;
+}
+
+/* The SVG <tspan> for "InnOSeed" — italic Fraunces, matching the
+   base layer's `.accent`. Color is omitted; it inherits `stroke`
+   from `.svgText` so the brand word gets the same amber outline as
+   the surrounding Chinese glyphs. */
+.svgAccent {
+  font-family: var(--ff-display);
+  font-style: italic;
+  font-weight: 800;
+  letter-spacing: -0.04em;
+}
+
+/* Mobile (≤720px): tighten the headline's vertical margin and the
+   font-size cap so the three rows still fit comfortably inside the
+   first viewport. The SVG overlay's font-size must track the base
+   layer's, otherwise the dashed outline floats above the wrong
+   glyph positions. Was carried over from the v4 globals.css rules. */
+@media (max-width: 720px) {
+  .headline {
+    margin: 14px 0 24px;
+    font-size: clamp(40px, 10vw, 96px);
+    letter-spacing: -0.02em;
+  }
+  .svgText {
+    font-size: clamp(40px, 10vw, 96px);
+    letter-spacing: -0.02em;
+  }
+}
+
+/* Ultra-small (≤360px, iPhone SE 1): cap the headline at a floor of
+   32px so it stays readable inside a 320px-wide viewport without
+   horizontal overflow. */
+@media (max-width: 360px) {
+  .headline {
+    font-size: 32px;
+  }
+  .svgText {
+    font-size: 32px;
+  }
+}
+
+/* Reduced-motion users see the dashed overlay instantly — no fade-in
+   delay — since they don't get the hero-rise entry animation
+   either. */
+@media (prefers-reduced-motion: reduce) {
+  .overlay {
+    opacity: 1;
+    animation: none;
+  }
+}

--- a/src/components/Hero.tsx
+++ b/src/components/Hero.tsx
@@ -1,7 +1,9 @@
 import { useRef } from 'react';
 import useReveal from '../hooks/useReveal';
 import useHeroParallax from '../hooks/useHeroParallax';
+import useHeroSweep from '../hooks/useHeroSweep';
 import { HERO } from '../content/site';
+import styles from './Hero.module.css';
 
 /**
  * Hero — first viewport.
@@ -12,7 +14,74 @@ import { HERO } from '../content/site';
  * actually see — the big accent text is the headline, the thinner
  * sentence is the lede. Each animatable element has its own
  * useReveal so the entry transition fires once it enters viewport.
+ *
+ * The h1 paints its rows twice as two stacked layers
+ * (`.base` + `.overlay`) so the hover sweep can reveal an amber
+ * copy over a base ink-dark copy via clip-path, without relying on
+ * `background-clip: text` (which renders inconsistently across some
+ * Chromium variants — including the Playwright headless shell that
+ * runs our e2e suite). The base layer is always visible, so the
+ * headline is never blank.
+ *
+ * All headline-related styles live in `Hero.module.css`, not in
+ * `globals.css`. The reveal / fade-up observer (`useReveal`) is a
+ * project-wide concern, so its `.reveal` / `.reveal.in` classes
+ * stay in globals.css; we compose them here via the bare `reveal`
+ * string literal.
  */
+function renderHeadlineRows() {
+  return HERO.headlineRows.map((row, i) => (
+    <span className={styles.row} key={i}>
+      <span>
+        {row.text !== undefined ? (
+          row.text
+        ) : (
+          <>
+            <span className={styles.accent}>{row.lead}</span>
+            {row.trail}
+          </>
+        )}
+      </span>
+    </span>
+  ));
+}
+
+/**
+ * SVG-flavored variant of `renderHeadlineRows`, used by the overlay
+ * layer so each glyph can carry a dashed `stroke` (via SVG's
+ * `stroke-dasharray`, which CSS Modules / `-webkit-text-stroke`
+ * cannot replicate). `fill: transparent` on the overlay means the
+ * base layer's ink-dark text shows through the SVG glyphs — only
+ * the dashed amber outline is visible, which is the "速写本 dashed
+ * edge" effect the user asked for.
+ *
+ * Baseline alignment note: SVG `<text y="1em">` puts the first
+ * baseline at 1em from the SVG top (matching the .row's
+ * line-height: 1.0 layout in HTML). Each `<tspan dy="1em">` then
+ * drops the next baseline by exactly 1em, so the two rows line up
+ * pixel-for-pixel with the base layer's HTML glyphs.
+ */
+function renderSvgHeadlineRows() {
+  return HERO.headlineRows.map((row, i) => {
+    const inner =
+      row.text !== undefined ? (
+        row.text
+      ) : (
+        <>
+          <tspan className={styles.svgAccent}>{row.lead}</tspan>
+          {row.trail}
+        </>
+      );
+    return (
+      // dy="1em" on every row including the first — the SVG <text>
+      // baseline at y="1em" is the first baseline, and dy is the
+      // spacing between consecutive baselines (== line-height).
+      <tspan key={i} x="0" dy="1em">
+        {inner}
+      </tspan>
+    );
+  });
+}
 export default function Hero() {
   const imgRef = useHeroParallax();
   const tagRef = useRef<HTMLDivElement | null>(null);
@@ -26,6 +95,10 @@ export default function Hero() {
   useReveal(ledeRef);
   useReveal(subRef);
   useReveal(ctaRef);
+  // Reuse the same h1Ref — useReveal only adds an `.in` class via
+  // IntersectionObserver; useHeroSweep only writes a CSS variable via
+  // mousemove. They never conflict on the same node.
+  useHeroSweep(h1Ref);
 
   return (
     <section className="hero" id="top">
@@ -63,21 +136,17 @@ export default function Hero() {
         <div ref={tagRef} className="hero-tag reveal">
           {HERO.tag}
         </div>
-        <h1 ref={h1Ref} className="hero-headline reveal" data-delay="1">
-          {HERO.headlineRows.map((row, i) => (
-            <div className="row" key={i}>
-              <span>
-                {row.text !== undefined ? (
-                  row.text
-                ) : (
-                  <>
-                    <span className="accent">{row.lead}</span>
-                    {row.trail}
-                  </>
-                )}
-              </span>
-            </div>
-          ))}
+        <h1 ref={h1Ref} className={`${styles.headline} reveal`} data-delay="1">
+          <span className={styles.layer}>{renderHeadlineRows()}</span>
+          <svg
+            className={`${styles.layer} ${styles.overlay}`}
+            aria-hidden="true"
+            preserveAspectRatio="xMinYMin meet"
+          >
+            <text className={styles.svgText} y="-0.15em">
+              {renderSvgHeadlineRows()}
+            </text>
+          </svg>
         </h1>
         <p ref={ledeRef} className="hero-lede reveal" data-delay="2">
           {HERO.lead}

--- a/src/hooks/useHeroSweep.ts
+++ b/src/hooks/useHeroSweep.ts
@@ -1,0 +1,79 @@
+import { useEffect, type RefObject } from 'react';
+
+/**
+ * useHeroSweep — drive a vertical "light bar" that follows the cursor
+ * inside an element. Writes the cursor's local Y position (relative to
+ * the element's bounding rect) to a `--sweep-y` CSS variable on the
+ * element; the companion CSS in globals.css uses that variable to
+ * split a two-color `background-image` on the element into top/bottom
+ * halves (see the `.hero h1.hero-headline` rule under
+ * `@media (hover: hover) and (pointer: fine)`).
+ *
+ * Implementation notes:
+ *   - rAF-throttled mousemove so we never write to the DOM faster than
+ *     the browser can paint.
+ *   - Listeners are attached to `window`, not the element itself, so a
+ *     sibling element scrolling under the cursor doesn't drop the move
+ *     event.
+ *   - On `mouseleave` (over `window` — i.e. cursor left the page) we
+ *     snap `--sweep-y` back to `0` so the headline settles to its
+ *     default single-color state. We don't reset on every in-page move
+ *     because the cursor naturally traverses the element.
+ *   - Disabled entirely on coarse pointers (touch devices) and when
+ *     `prefers-reduced-motion: reduce` is set. The hook returns nothing
+ *     in those cases; the headline falls back to its static colors.
+ */
+export default function useHeroSweep<T extends HTMLElement>(
+  ref: RefObject<T>
+): void {
+  useEffect(() => {
+    const el = ref.current;
+    if (!el) return undefined;
+    if (typeof window === 'undefined') return undefined;
+    const finePointer = window
+      .matchMedia('(hover: hover) and (pointer: fine)')
+      .matches;
+    if (!finePointer) return undefined;
+    const reduceMotion = window
+      .matchMedia('(prefers-reduced-motion: reduce)')
+      .matches;
+    if (reduceMotion) return undefined;
+
+    let rafId = 0;
+    let pendingY: number | null = null;
+
+    const flush = () => {
+      rafId = 0;
+      if (pendingY === null) return;
+      el.style.setProperty('--sweep-y', `${pendingY}px`);
+      pendingY = null;
+    };
+
+    const onMove = (e: MouseEvent) => {
+      const rect = el.getBoundingClientRect();
+      const y = e.clientY - rect.top;
+      // Clamp so the gradient still resolves when the cursor is just
+      // above or just below the element (still in viewport but outside
+      // the h1 box). Otherwise the gradient would render with a "void"
+      // in the middle on the very first frame.
+      const clamped = Math.max(0, Math.min(rect.height, y));
+      pendingY = clamped;
+      if (rafId === 0) rafId = requestAnimationFrame(flush);
+    };
+
+    const onLeave = () => {
+      pendingY = 0;
+      if (rafId === 0) rafId = requestAnimationFrame(flush);
+    };
+
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseleave', onLeave);
+    return () => {
+      if (rafId !== 0) cancelAnimationFrame(rafId);
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseleave', onLeave);
+      // Reset so HMR / route changes don't leave a stale sweep line.
+      el.style.removeProperty('--sweep-y');
+    };
+  }, [ref]);
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -162,6 +162,14 @@
   --c-startup:  #1E40AF;   /* 蓝 */
   --c-bonds:    #991B1B;   /* 红 */
 
+  /* Warm accent — distinct from the cool brand/pillar palette.
+     Used as the Hero headline sweep-light highlight color (so the
+     cursor sweep reads over the brand-blue "InnOSeed" accent em) and
+     as the skip-link :focus-visible outline. Spec §7 lists this
+     token but it was previously undefined; landing it here closes
+     that dangling reference. */
+  --accent-amber: #D97706;
+
   /* Type families — system fonts come FIRST so most visitors (macOS, iOS,
      Windows, modern Android) never download Noto SC. Noto SC is the
      last fallback for Linux / older Android without system Chinese. */
@@ -501,73 +509,13 @@ section { position: relative; }
   display: inline-block;
 }
 
-.hero h1 {
-  font-family: var(--ff-zh);
-  font-weight: 700;
-  /* Smaller than the headline — keep it as a lead sentence, not a poster. */
-  font-size: clamp(20px, 2.4vw, 32px);
-  line-height: 1.35;
-  letter-spacing: -0.005em;
-  margin-bottom: 14px;
-  max-width: 980px;
-  color: var(--ink-dark);
-  /* Let Latin words like "different thinkers" sit naturally inside the CN line. */
-  word-break: keep-all;
-  overflow-wrap: break-word;
-}
-.hero h1 em {
-  font-family: var(--ff-sans);
-  font-style: normal;
-  font-weight: 700;
-  color: var(--brand);
-  padding: 0 0.15em;
-  position: relative;
-}
-.hero h1 em::after {
-  content: '';
-  position: absolute;
-  left: 0.12em; right: 0.12em; bottom: 0.06em;
-  height: 0.12em;
-  background: rgba(28,100,242,0.18);
-  z-index: -1;
-  border-radius: 2px;
-}
-
-.hero h1.hero-headline {
-  /* Unify with editorial section headings — Fraunces (Latin) + Source Han Serif
-     (CJK) — so the brand statement shares the typographic register of the
-     Manifesto / Pillars / Numbers / Members / Recruit headlines that follow. */
-  font-family: var(--ff-display);
-  font-weight: 800;
-  /* Cap so the three rows fit inside 100vh. Old --fs-display went to 220px. */
-  font-size: clamp(56px, 8vw, 128px);
-  line-height: 1.0;
-  letter-spacing: -0.035em;
-  color: var(--ink-dark);
-  margin: 10px 0 22px;
-  max-width: 1300px;
-}
-.hero-headline .row { display: block; overflow: hidden; }
-.hero-headline .row span {
-  display: inline-block;
-  transform: translateY(110%);
-  animation: hero-rise 1.2s cubic-bezier(0.22, 1, 0.36, 1) forwards;
-}
-.hero-headline .row:nth-child(1) span { animation-delay: 0.2s; }
-.hero-headline .row:nth-child(2) span { animation-delay: 0.45s; }
-.hero-headline .row:nth-child(3) span { animation-delay: 0.7s; }
-@keyframes hero-rise { to { transform: translateY(0); } }
-.hero-headline .accent {
-  /* Match the section <em> treatment (Manifesto / Pillars / Numbers /
-     Members / Recruit / page-header h1): italic Fraunces for the Latin
-     brand name, weighted and tinted brand-blue so "InnOSeed" still
-     reads as the visual anchor inside the serif block. */
-  font-family: var(--ff-display);
-  font-style: italic;
-  font-weight: 800;
-  color: var(--brand);
-  letter-spacing: -0.04em;
-}
+/* No .hero h1 lead-sentence rule:
+   The hero h1 is now the module-styled hero headline (see
+   Hero.module.css). Previous v3 versions of this site had a h1 that
+   doubled as a "lead sentence" above a separate headline element;
+   that h1 is gone, and so is the matching rule. Keeping the rule
+   here would (a) create a CSS specificity fight against the module
+   and (b) match nothing. */
 
 .hero-sub {
   font-family: var(--ff-zh);
@@ -2015,8 +1963,6 @@ main .page-header-desc {
   /* Hero */
   .hero-inner { padding: 110px 0 72px; }
   .hero-tag { font-size: 11px; padding: 6px 12px; margin-bottom: 24px; letter-spacing: 0.22em; }
-  .hero h1 { font-size: clamp(22px, 6vw, 56px); margin-bottom: 18px; }
-  .hero h1.hero-headline { margin: 14px 0 24px; font-size: clamp(40px, 10vw, 96px); letter-spacing: -0.02em; }
   .hero-sub { font-size: 15px; line-height: 1.6; margin-bottom: 32px; }
   .hero-cta {
     flex-direction: column;
@@ -2097,8 +2043,6 @@ main .page-header-desc {
     --gutter: 20px;
     --fs-display: clamp(44px, 13vw, 220px);
   }
-  .hero h1 { font-size: 21px; }
-  .hero h1.hero-headline { font-size: 32px; }
   .recruit h2 { font-size: 30px; }
   .pillar-name { font-size: 26px; }
 }


### PR DESCRIPTION
桌面端 hover 时，光标进入 hero headline 区域会把顶部 sweep-y以上的字形切换为琥珀色填充 + 黑色 dashed 描边的叠加效果

本次修改了 `spec.md` 添加了琥珀色颜色 token，此外，使用 Module CSS，而不是继续在 global.css 中增加代码，请参考 https://vite.dev/guide/features#css-modules

预览效果：

<img width="1152" height="458" alt="PixPin_2026-08-15_00-51-35" src="https://github.com/user-attachments/assets/8e93dca4-97c4-4db9-a21a-2edf33a277bd" />
