### PR TITLE
fix(nav): 顶部导航往两边拉开一点

### DIFF
--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -306,6 +306,9 @@ section { position: relative; }
 .nav-top-inner {
   display: flex; align-items: center; justify-content: space-between;
   gap: 24px;
+  /* Top bar only: sit a bit wider than section .container (--max 1320)
+     so brand / Mini Camp breathe toward the viewport edges. */
+  max-width: 1520px;
 }
 .brand {
   display: flex; align-items: center; gap: 12px;
@@ -2068,7 +2071,7 @@ html.has-sidebar {
      so its pills don't overlap section content near the edge. The
      sidebar is ~140px wide on a 1440 viewport, so 160px is a safe
      floor that still leaves plenty of room for the main column. */
-  html.has-sidebar .container {
+  html.has-sidebar .container:not(.nav-top-inner) {
     padding-right: max(40px, calc(var(--nav-sidebar-w, 140px) + 40px));
   }
 }


### PR DESCRIPTION
## 改动

把顶部 nav 的 `nav-top-inner` max-width 从跟随 `.container` (1320px) 抬到 1520px,让品牌 / Mini Camp 在主流视口能向两侧呼吸一点空间。同时把 sidebar 偏移规则 `html.has-sidebar .container` 收紧为 `:not(.nav-top-inner)`,免得顶部那条跟着被挤。

## Diff

仅 `src/styles/globals.css` 一个文件,4 行新增 / 1 行修改:

- `.nav-top-inner` 加 `max-width: 1520px`
- `html.has-sidebar .container` → `html.has-sidebar .container:not(.nav-top-inner)`

## 验证

纯样式微调,不动文案 / spec / 表单 / 路由。